### PR TITLE
fix: unpin 6.11.3 kernel

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["aurora"]
     with:
-      kernel_pin: 6.11.3-300.fc41.x86_64
+# kernel_pin: 6.11.3-300.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Bluefin just removed the kernel pin here: https://github.com/ublue-os/bluefin/pull/2021
I think Aurora should do the same.