### PR TITLE
fix: aurora documentation URL

### DIFF
--- a/system_files/kinoite/usr/share/applications/documentation.desktop
+++ b/system_files/kinoite/usr/share/applications/documentation.desktop
@@ -2,7 +2,7 @@
 Type=Application
 NoDisplay=false
 Terminal=false
-Exec=xdg-open https://docs.getaurora.dev/guides/intro/
+Exec=xdg-open https://docs.getaurora.dev/guides/basic-usage
 Icon=ublue-docs
 Name=Documentation
 Comment=Aurora documentation


### PR DESCRIPTION
The current URL https://docs.getaurora.dev/guides/intro/ leads to "Page Not Found".  This commit fixes that and instead points to https://docs.getaurora.dev/guides/basic-usage. 

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
