### PR TITLE
fix: remove libadwaita-qt{5,6} packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -88,8 +88,6 @@
 				"kdenetwork-filesharing",
 				"kdeplasma-addons",
 				"kdialog",
-				"libadwaita-qt5",
-				"libadwaita-qt6",
 				"plasma-wallpapers-dynamic",
 				"skanpage"
 			],


### PR DESCRIPTION
All image builds are failing with the following error (from https://github.com/ublue-os/aurora/actions/runs/12336280554/job/34428627112):

```
error: Could not depsolve transaction; 2 problems detected:
 Problem 1: conflicting requests
  - installed package qt5-qtbase-gui-5.15.15-3.fc41.x86_64 obsoletes libadwaita-qt5 <= 1.4.2 provided by libadwaita-qt5-1.4.2-8.fc41.i686 from fedora
  - installed package qt5-qtbase-gui-5.15.15-3.fc41.x86_64 obsoletes libadwaita-qt5 <= 1.4.2 provided by libadwaita-qt5-1.4.2-8.fc41.x86_64 from fedora
 Problem 2: conflicting requests
  - installed package qt6-qtbase-gui-6.8.1-5.fc41.x86_64 obsoletes libadwaita-qt6 <= 1.4.2 provided by libadwaita-qt6-1.4.2-8.fc41.i686 from fedora
  - installed package qt6-qtbase-gui-6.8.1-5.fc41.x86_64 obsoletes libadwaita-qt6 <= 1.4.2 provided by libadwaita-qt6-1.4.2-8.fc41.x86_64 from fedora
Error: building at STEP "RUN --mount=type=cache,dst=/var/cache/rpm-ostree --mount=type=bind,from=ctx,source=/,target=/ctx /ctx/build_files/shared/build-base.sh": while running runtime: exit status 1
error: Recipe `build` failed with exit code 1
error: Recipe `build-ghcr` failed with exit code 1
```

According to the [FedoraQt/adwaita-qt](https://github.com/FedoraQt/adwaita-qt) repository, the `adwaita-qt` project is dead. Both `libadwaita-qt5` and `libadwaita-qt6` have been recently purged from Fedora's packaging sources. 

See this commit as an example: https://src.fedoraproject.org/rpms/adwaita-qt/c/924ff971ac92d6504260e2578c60e2dc59877557?branch=rawhide

Removing these two packages causes the image build process to succeed again.

**Other resources**
- https://packages.fedoraproject.org/pkgs/adwaita-qt/libadwaita-qt6/
- https://packages.fedoraproject.org/pkgs/adwaita-qt/libadwaita-qt6/

---
**Edit**: It looks like [this commit](https://src.fedoraproject.org/rpms/qt6-qtbase/c/2fa0a5471428d6534dc90fe83c3be449de53234b?branch=rawhide) from [rpms/qt6-qtbase](https://src.fedoraproject.org/rpms/qt6-qtbase/) that was committed a few days ago is to blame for this. It adds `Obsoletes` directives for `libadwaita-qt6` which causes the error shown above.

```diff


diff --git a/qt6-qtbase.spec b/qt6-qtbase.spec
index ed3665f..9efa172 100644
--- a/qt6-qtbase.spec
+++ b/qt6-qtbase.spec
@@ -46,7 +46,7 @@ BuildRequires: pkgconfig(libsystemd)
 Name:    qt6-qtbase
 Summary: Qt6 - QtBase components
 Version: 6.8.1
-Release: 4%{?dist}
+Release: 5%{?dist}
 
 License: LGPL-3.0-only OR GPL-3.0-only WITH Qt-GPL-exception-1.0
 Url:     http://qt-project.org/
@@ -212,6 +212,8 @@ handling.
 %package common
 Summary: Common files for Qt6
 Requires: %{name} = %{version}-%{release}
+Obsoletes: qgnomeplatform-common <= 0.9.2
+Provides:  qgnomeplatform-common = %{version}-%{release}
 BuildArch: noarch
 %description common
 %{summary}.
@@ -311,6 +313,10 @@ Recommends: mesa-dri-drivers%{?_isa}
 Recommends: qt6-qtwayland%{?_isa}
 # Required for some locales: https://pagure.io/fedora-kde/SIG/issue/311
 Recommends: qt6-qttranslations
+Obsoletes: adwaita-qt6 <= 1.4.2
+Obsoletes: libadwaita-qt6 <= 1.4.2
+Obsoletes: qgnomeplatform-qt6 <= 0.9.2
+Provides:  qgnomeplatform-qt6 = %{version}-%{release}
 # for Source6: 10-qt6-check-opengl2.sh:
 # glxinfo
 Requires: glx-utils
@@ -886,6 +892,9 @@ make check -k ||:
 
 
 %changelog
+* Tue Dec 10 2024 Jan Grulich <jgrulich@redhat.com> - 6.8.1-5
+- Obsolete QGnomePlatform and AdwaitaQt
+
 * Sat Dec 07 2024 Jan Grulich <jgrulich@redhat.com> - 6.8.1-4
 - Move all mkspecs to -devel
 ```