### PR TITLE
fix: remove wl akmod

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -39,7 +39,6 @@ rpm-ostree install \
     https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
     https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
 rpm-ostree install \
-    broadcom-wl /tmp/akmods/kmods/*wl*.rpm \
     v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
 rpm-ostree uninstall rpmfusion-free-release rpmfusion-nonfree-release
 


### PR DESCRIPTION
Pulling in Broadcom fix from Bluefin. See https://github.com/ublue-os/bluefin/pull/2070 and https://github.com/ublue-os/bluefin/issues/1783.

Related Discourse thread: https://universal-blue.discourse.group/t/more-broadcom-wifi-madness-possible-ujust-akmods-script-typo/4836/5