### PR TITLE
fix: remove pkcs11-provider workaround

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -7,9 +7,12 @@ if [[ -f /usr/bin/ld.bfd ]]; then
     ln -sf /usr/bin/ld.bfd /etc/alternatives/ld && ln -sf /etc/alternatives/ld /usr/bin/ld
 fi
 
-
 ## Pins and Overrides
 ## Use this section to pin packages in order to avoid regressions
-if [ "$FEDORA_MAJOR_VERSION" -eq "41" ]; then
-    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225    
-fi
+# Remember to leave a note with rationale/link to issue for each pin!
+#
+# Example:
+#if [ "$FEDORA_MAJOR_VERSION" -eq "41" ]; then
+#    Workaround pkcs11-provider regression, see issue #1943
+#    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
+#fi


### PR DESCRIPTION
This pin is no longer needed and was removed in https://github.com/ublue-os/bluefin/pull/1993. Pulling in the same changes.