### PR TITLE
chore: remove references to GTS

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -375,11 +375,6 @@ def generate_changelog(
 
     changelog = CHANGELOG_FORMAT
 
-    if target == "gts":
-        changelog = changelog.splitlines()
-        del changelog[9]
-        changelog = '\n'.join(changelog)
-
     changelog = (
         changelog.replace("{handwritten}", handwritten if handwritten else HANDWRITTEN_PLACEHOLDER)
         .replace("{target}", target)

--- a/Justfile
+++ b/Justfile
@@ -100,10 +100,6 @@ validate image="" tag="" flavor="":
         echo "Invalid flavor..."
         exit 1
     fi
-    if [[ "$checktag" =~ gts && "$checkimage" =~ aurora ]]; then
-        echo "Aurora Does not build GTS..."
-        exit 1
-    fi
     if [[ ! "$checktag" =~ latest && "$checkflavor" =~ hwe|asus|surface ]]; then
         echo "HWE images are only built on latest..."
         exit 1
@@ -155,7 +151,7 @@ build image="aurora" tag="latest" flavor="main" rechunk="0" ghcr="0" pipeline="0
     # AKMODS Flavor and Kernel Version
     if [[ "${flavor}" =~ hwe ]]; then
         akmods_flavor="bazzite"
-    elif [[ "${tag}" =~ stable|gts ]]; then
+    elif [[ "${tag}" =~ stable ]]; then
         akmods_flavor="coreos-stable"
     elif [[ "${tag}" =~ beta ]]; then
         akmods_flavor="coreos-testing"

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -58,7 +58,7 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
     rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
 fi
 
-# ZFS for gts/stable
+# ZFS for stable
 if [[ ${AKMODS_FLAVOR} =~ coreos ]]; then
     # Fetch ZFS RPMs
     skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/akmods-zfs:"${AKMODS_FLAVOR}"-"$(rpm -E %fedora)"-"${KERNEL}" dir:/tmp/akmods-zfs

--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -15,13 +15,7 @@ function rebase_helper(){
     base_image="ghcr.io/ublue-os/${IMAGE_NAME}"
     echo "Which Tag would you like to rebase to?"
     CHANNELS=(latest stable stable-daily)
-    # Aurora currently does not have GTS (02-11-2024)
-    if [[ "${IMAGE_NAME}" =~ "aurora" ]]; then
-        echo "The default selection is stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
-    else
-        CHANNELS+=(gts)
-        echo "The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
-    fi
+    echo "The default selection is stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
     choose_target=$(Choose date "${CHANNELS[@]}" cancel)
     if [[ "$choose_target" != "date" && "$choose_target" != "cancel" ]]; then
         rebase_target="${base_image}:${choose_target}"
@@ -38,9 +32,6 @@ function rebase_helper(){
         fi
     else
         return 1
-    fi
-    if  [[ "$choose_target" =~ "gts" && "$IMAGE_TAG" != "$choose_target" ]]; then
-        echo "Warning rolling back Major Fedora Versions may not work"
     fi
     echo "Rebase Target is ${rebase_target}"
     echo "Confirm Rebase"


### PR DESCRIPTION
GTS is only meaningful in Bluefin, so we can remove some of this dead code and outdated comments.