### PR TITLE
chore(build-dx): consolidate os-release names

### DIFF
--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -28,8 +28,7 @@ sysctl -p
 /ctx/build_files/dx/04-override-install-dx.sh
 
 # Branding Changes
-sed -i '/^PRETTY_NAME/s/Aurora/Aurora-dx/' /usr/lib/os-release
-sed -i 's/Aurora/Aurora-DX/' /usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
+echo "Variant=Developer Experience" >> /usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
 
 # Systemd and Disable Repos
 /ctx/build_files/dx/09-cleanup-dx.sh

--- a/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
+++ b/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
@@ -2,4 +2,3 @@
 LogoPath=/usr/share/pixmaps/system-logo.png
 Name=Aurora
 Website=https://getaurora.dev
-Variant=Aurora


### PR DESCRIPTION
This PR contains two separate but related changes:

## Use same `PRETTY_NAME` for Aurora and Aurora-dx

Mostly pulling from Bluefin's recent change https://github.com/ublue-os/bluefin/pull/2090 to make it so both `Aurora` and `Aurora-dx` count as a single entry in Homebrew's stats.

This should bump Aurora up a few spots on https://formulae.brew.sh/analytics/os-version/30d.

## Change name in KDE's Info Center

The `kcm-about-distrorc` file controls what is displayed in KDE's Info Center app. I noticed that Aurora's Info Center is using the `Variant` field in a way that is both redundant (i.e., it is just the `Name` field repeated) and different from how other KDE-based projects use that field, including Bazzite.

### Current

![Screenshot_20250103_012617](https://github.com/user-attachments/assets/ec57bf63-4bb0-4782-b063-eed13c4c6e2b)

### Proposed
![Screenshot_20250103_022127](https://github.com/user-attachments/assets/a5e9a62c-c940-4452-b89e-96b98a69e255)

I feel that having the `Variant` field be empty for the Aurora image and "Developer Experience" for the Aurora-dx image is more in line with the spirit of the field. I am attaching examples from other distros to provide a feel for how others do it.

### Other Distros

![Screenshot_20250103_020847](https://github.com/user-attachments/assets/3a03dc27-4ddb-40ae-83ce-65924af38009)
![Screenshot_20250103_012224](https://github.com/user-attachments/assets/74530118-4f40-4be1-a584-d2c1ac46b2ab)
![Screenshot_20250103_013005](https://github.com/user-attachments/assets/ef0ae145-c31a-4d94-ada2-0d3b9fe6e15e)
![Screenshot_20250103_012456](https://github.com/user-attachments/assets/691d033d-8e09-456d-a284-639d06a44018)
