### PR TITLE
fix: add shebang to /usr/bin/sb-key-notify

### DIFF
--- a/system_files/shared/usr/bin/sb-key-notify
+++ b/system_files/shared/usr/bin/sb-key-notify
@@ -1,3 +1,4 @@
+#!/bin/bash
 KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
 
 if [ -e $KEY_WARN_FILE ]; then


### PR DESCRIPTION
I discovered that the `sb-key-notify` service was repeatedly failing to run automatically on my install with the message "`Exec format error`". A quick search discovered that the issue is that this file is missing a shebang, so systemd/KDE don't know to launch it in a shell interpreter. I did a quick test on my installation with a modified script and it seems to work.

I see [some indication on the forums](https://universal-blue.discourse.group/t/various-errors-at-boot/5574) that some other people have seen this issue, although it's not clear if it's universally the case. I also took a quick look at bluefin, [which seems to have the same issue](https://github.com/ublue-os/bluefin/blob/main/system_files/shared/usr/bin/sb-key-notify) (in the script at least, not sure if GNOME is able to launch the script without the shebang).

AFAICT, Bazzite does not appear to have this script.