### PR TITLE
chore: remove systemd unit disable for unknown services on aurora-dx

### DIFF
--- a/build_files/dx/09-cleanup-dx.sh
+++ b/build_files/dx/09-cleanup-dx.sh
@@ -8,8 +8,6 @@ systemctl enable swtpm-workaround.service
 systemctl enable libvirt-workaround.service
 systemctl enable aurora-dx-groups.service
 systemctl enable --global aurora-dx-user-vscode.service
-systemctl disable pmie.service
-systemctl disable pmlogger.service
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo
 if [[ -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo ]]; then


### PR DESCRIPTION
There are no units named `pmie.service` or `pmlogger.service`. Trying to disable them is throwing errors that these units do not exist when building dx variants.

I pushed similar changes to Bluefin: https://github.com/ublue-os/bluefin/pull/2105

See: https://github.com/ublue-os/aurora/actions/runs/12604792860/job/35132349109

```
2025-01-03T22:43:58.4097786Z + systemctl disable pmie.service
2025-01-03T22:43:58.4218039Z Failed to disable unit: Unit pmie.service does not exist
2025-01-03T22:43:58.4218766Z Failed to disable unit: Unit pmie.service does not exist
2025-01-03T22:43:58.4219883Z The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=,
2025-01-03T22:43:58.4220913Z Also=, or Alias= settings in the [Install] section, and DefaultInstance= for
2025-01-03T22:43:58.4221740Z template units). This means they are not meant to be enabled or disabled using systemctl.
2025-01-03T22:43:58.4222286Z  
2025-01-03T22:43:58.4222604Z Possible reasons for having these kinds of units are:
2025-01-03T22:43:58.4223476Z • A unit may be statically enabled by being symlinked from another unit's
2025-01-03T22:43:58.4224281Z   .wants/, .requires/, or .upholds/ directory.
2025-01-03T22:43:58.4225361Z • A unit's purpose may be to act as a helper for some other unit which has
2025-01-03T22:43:58.4226154Z   a requirement dependency on it.
2025-01-03T22:43:58.4226993Z • A unit may be started when needed via activation (socket, path, timer,
2025-01-03T22:43:58.4227524Z   D-Bus, udev, scripted systemctl call, ...).
2025-01-03T22:43:58.4228092Z • In case of template units, the unit is meant to be enabled with some
2025-01-03T22:43:58.4228566Z   instance name specified.
2025-01-03T22:43:58.4228908Z + systemctl disable pmlogger.service
2025-01-03T22:43:58.4343081Z Failed to disable unit: Unit pmlogger.service does not exist
2025-01-03T22:43:58.4344002Z Failed to disable unit: Unit pmlogger.service does not exist
2025-01-03T22:43:58.4344938Z The unit files have no installation config (WantedBy=, RequiredBy=, UpheldBy=,
2025-01-03T22:43:58.4345752Z Also=, or Alias= settings in the [Install] section, and DefaultInstance= for
2025-01-03T22:43:58.4346628Z template units). This means they are not meant to be enabled or disabled using systemctl.
2025-01-03T22:43:58.4347221Z  
2025-01-03T22:43:58.4347564Z Possible reasons for having these kinds of units are:
2025-01-03T22:43:58.4348316Z • A unit may be statically enabled by being symlinked from another unit's
2025-01-03T22:43:58.4349257Z   .wants/, .requires/, or .upholds/ directory.
2025-01-03T22:43:58.4350131Z • A unit's purpose may be to act as a helper for some other unit which has
2025-01-03T22:43:58.4350739Z   a requirement dependency on it.
2025-01-03T22:43:58.4351436Z • A unit may be started when needed via activation (socket, path, timer,
2025-01-03T22:43:58.4352115Z   D-Bus, udev, scripted systemctl call, ...).
2025-01-03T22:43:58.4352963Z • In case of template units, the unit is meant to be enabled with some
2025-01-03T22:43:58.4353530Z   instance name specified.
```