### PR TITLE
fix(actions): try to recover if just fails to install

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -36,14 +36,8 @@ jobs:
 
       - name: Install Just
         shell: bash
-        run: |
-          set -eoux pipefail
-          JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
-          curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
-          sudo mv /tmp/just /usr/local/bin/just
-          rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-        
+        run: bash .github/workflows/shared/install-just.sh
+
       - name: Check Just Syntax
         shell: bash
         run: |

--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -39,13 +39,7 @@ jobs:
 
       - name: Install Just
         shell: bash
-        run: |
-          set -eoux pipefail
-          JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
-          curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
-          sudo mv /tmp/just /usr/local/bin/just
-          rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+        run: bash .github/workflows/shared/install-just.sh
 
       - name: Check Just Syntax
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -48,13 +48,7 @@ jobs:
       
       - name: Install Just
         shell: bash
-        run: |
-          set -eoux pipefail
-          JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
-          curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
-          sudo mv /tmp/just /usr/local/bin/just
-          rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+        run: bash .github/workflows/shared/install-just.sh
         
       - name: Check Just Syntax
         shell: bash

--- a/.github/workflows/shared/install-just.sh
+++ b/.github/workflows/shared/install-just.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eoux pipefail
-JUST_VERSION=$(curl --retry 3 --retry-all-errors -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
-if [[ "${JUST_VERSION}" == "null" ]]; then
-  JUST_VERSION=1.38.0
-fi
+while [[ "${JUST_VERSION:-}" =~ null || -z "${JUST_VERSION:-}" ]]
+do
+    JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
+done
 curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
 tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
 sudo mv /tmp/just /usr/local/bin/just

--- a/.github/workflows/shared/install-just.sh
+++ b/.github/workflows/shared/install-just.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eoux pipefail
+JUST_VERSION=$(curl --retry 3 --retry-all-errors -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
+if [[ "${JUST_VERSION}" == "null" ]]; then
+  JUST_VERSION=1.38.0
+fi
+curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
+sudo mv /tmp/just /usr/local/bin/just
+rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz

--- a/.github/workflows/shared/install-just.sh
+++ b/.github/workflows/shared/install-just.sh
@@ -4,7 +4,7 @@ while [[ "${JUST_VERSION:-}" =~ null || -z "${JUST_VERSION:-}" ]]
 do
     JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
 done
-curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-tar -zxvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
+curl -sSLO https://github.com/casey/just/releases/download/"${JUST_VERSION}"/just-"${JUST_VERSION}"-x86_64-unknown-linux-musl.tar.gz
+tar -zxvf just-"${JUST_VERSION}"-x86_64-unknown-linux-musl.tar.gz -C /tmp just
 sudo mv /tmp/just /usr/local/bin/just
-rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+rm -f just-"${JUST_VERSION}"-x86_64-unknown-linux-musl.tar.gz


### PR DESCRIPTION
Related to https://github.com/ublue-os/bluefin/pull/2106.

Lately, there are some flaky failures for jobs while installing `just`. For example, in the past few days, the following jobs to build images have failed:

- https://github.com/ublue-os/aurora/actions/runs/12607607121/job/35139162573
- https://github.com/ublue-os/aurora/actions/runs/12577208839/job/35054350351

The command `curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name'` is sometimes returning "null" instead of an actual version, but it's difficult to tell if the curl call is failing or if it's returning a payload that is being parsed incorrectly.

In either case, adding `--retry` to curl and if it's still null, hardcoding a known good version should do the trick for now.
