### PR TITLE
fix: artifacthub id

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
-repositoryID: d93848a7-1ba3-446f-a556-8cba07a42167
+repositoryID: 424dbc28-4b16-4590-bac7-2a8ee7c2eff7
 owners: # (optional, used to claim repository ownership)
   - name: Jorge Castro
     email: jorge.castro@gmail.com


### PR DESCRIPTION
This uses the correct artifacthub id to list aurora on artifacthub. tulip is going to PR the metadata changes. 

Feel free to add yourselves as owners at the bottom but leave mine in there as I'm running the org account in artifacthub.

For those not familiar with artifacthub it's a place that indexes cloud native artifacts, here's an example of what it looks like: https://artifacthub.io/packages/container/achillobator/achillobator

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
