### PR TITLE
fix: rollback stable images to 6.11.8 kernel

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,9 @@ jobs:
       matrix:
         brand_name: ["aurora"]
     with:
-      kernel_pin: 6.11.11-300.fc41.x86_64 ## See https://github.com/ublue-os/aurora/issues/82
+      # See https://github.com/ublue-os/aurora/issues/82
+      #  +  https://github.com/ublue-os/aurora/issues/120
+      kernel_pin: 6.11.8-300.fc41.x86_64
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Related to https://github.com/ublue-os/aurora/issues/120. People with IPU6 cameras are reporting crash on boot with 6.11.11.

https://github.com/ublue-os/bluefin/pull/2146