### PR TITLE
fix: fix ujust benchmark

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -13,7 +13,10 @@
 # Run a one minute system benchmark
 [group('System')]
 benchmark:
-    @echo 'Running a 1 minute benchmark ...'
+    #!/usr/bin/env bash
+    echo 'Running a 1 minute benchmark ...'
+    trap popd EXIT
+    pushd $(mktemp -d)
     stress-ng --matrix 0 -t 1m --times
 
 # Configure Aurora-CLI Terminal Experience with Brew


### PR DESCRIPTION
the `ujust benchmark`is broken as it tries to write somewhere thath is not writable.

copied this from https://github.com/ublue-os/bluefin/pull/2073
