### PR TITLE
feat: add org.gtk.Gtk3theme.Breeze for better GTK app integration

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -16,6 +16,4 @@ app/org.fedoraproject.MediaWriter/x86_64/stable
 app/io.missioncenter.MissionCenter/x86_64/stable
 app/org.gnome.DejaDup/x86_64/stable
 app/org.gnome.World.PikaBackup/x86_64/stable
-runtime/org.gtk.Gtk3theme.adw-gtk3/x86_64/3.22
-runtime/org.gtk.Gtk3theme.adw-gtk3-dark/x86_64/3.22
 runtime/org.gtk.Gtk3theme.Breeze/x86_64/3.22

--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -18,3 +18,4 @@ app/org.gnome.DejaDup/x86_64/stable
 app/org.gnome.World.PikaBackup/x86_64/stable
 runtime/org.gtk.Gtk3theme.adw-gtk3/x86_64/3.22
 runtime/org.gtk.Gtk3theme.adw-gtk3-dark/x86_64/3.22
+runtime/org.gtk.Gtk3theme.Breeze/x86_64/3.22


### PR DESCRIPTION
Fixes #132  

And removes adw-gtk flatpaks, we don't need those
