### PR TITLE
feat: overrides for Qt/GTK theming in flatpaks

### DIFF
--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Script Version
-VER=3
+VER=2
 VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/flatpak_manager_version"
 VER_RAN=$(cat "$VER_FILE")
 
@@ -13,8 +13,6 @@ if [[ -f $VER_FILE && $VER = "$VER_RAN" ]]; then
 	exit 0
 fi
 
-flatpak override --env=QT_QPA_PLATFORMTHEME=kde
-
 # Set up Firefox default configuration
 mkdir -p /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref
 rm -f /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref/*aurora*.js
@@ -23,8 +21,6 @@ rm -f /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable
 # Use until yafti rework is done
 flatpak --system update -y
 
-if [[ -z $VER_RAN ]]; then
-	notify-send "Welcome to Aurora" "Your computer is ready!" --app-name="Flatpak Manager Service" -u NORMAL
-fi
+notify-send "Welcome to Aurora" "Your computer is ready!" --app-name="Flatpak Manager Service" -u NORMAL
 
 echo $VER >"$VER_FILE"

--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Script Version
-VER=2
+VER=3
 VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/flatpak_manager_version"
 VER_RAN=$(cat "$VER_FILE")
 
@@ -13,6 +13,8 @@ if [[ -f $VER_FILE && $VER = "$VER_RAN" ]]; then
 	exit 0
 fi
 
+flatpak override --env=QT_QPA_PLATFORMTHEME=kde
+
 # Set up Firefox default configuration
 mkdir -p /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref
 rm -f /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref/*aurora*.js
@@ -21,6 +23,8 @@ rm -f /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable
 # Use until yafti rework is done
 flatpak --system update -y
 
-notify-send "Welcome to Aurora" "Your computer is ready!" --app-name="Flatpak Manager Service" -u NORMAL
+if [[ -z $VER_RAN ]]; then
+	notify-send "Welcome to Aurora" "Your computer is ready!" --app-name="Flatpak Manager Service" -u NORMAL
+fi
 
 echo $VER >"$VER_FILE"

--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # SCRIPT VERSION
-USER_SETUP_VER=7
+USER_SETUP_VER=8
 USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
 USER_SETUP_VER_RAN=$(cat "$USER_SETUP_VER_FILE")
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
@@ -56,6 +56,10 @@ if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
     touch "$UBLUE_CONFIG_DIR/framework-initialized"
   fi
 fi
+
+# More consistent Qt/GTK themes for Flatpaks
+flatpak override --env=QT_QPA_PLATFORMTHEME=kde
+flatpak override --filesystem=xdg-config/gtk-4.0:ro
 
 # Handle privileged tasks
 pkexec /usr/libexec/ublue-privileged-user-setup


### PR DESCRIPTION
Verified it works in a VM. After reboot:

```
> flatpak override --show
[Context]
filesystems=xdg-config/gtk-4.0:ro;

[Environment]
QT_QPA_PLATFORMTHEME=kde
```

Closes #131 and #130.