### PR TITLE
feat: add workaround for sddm theme (again)

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -14,6 +14,7 @@ systemctl enable brew-setup.service
 systemctl enable brew-upgrade.timer
 systemctl enable brew-update.timer
 systemctl enable aurora-groups.service
+systemctl enable usr-share-sddm-themes.mount
 systemctl --global enable ublue-user-setup.service
 systemctl --global enable podman-auto-update.timer
 systemctl enable check-sb-key.service

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -139,7 +139,7 @@ install-opentabletdriver:
     mkdir -p $HOME/.config/OpenTabletDriver && \
     flatpak override --user --filesystem=xdg-config/OpenTabletDriver net.opentabletdriver.OpenTabletDriver && \
     mkdir -p $HOME/.config/systemd/user && \
-    curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > ~/.config/systemd/user/opentabletdriver.service  && \
+    curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > $HOME/.config/systemd/user/opentabletdriver.service  && \
     systemctl --user daemon-reload && \
     systemctl enable --user --now opentabletdriver.service
 

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -138,6 +138,7 @@ install-opentabletdriver:
     flatpak --system install -y flathub net.opentabletdriver.OpenTabletDriver && \
     mkdir -p $HOME/.config/OpenTabletDriver && \
     flatpak override --user --filesystem=xdg-config/OpenTabletDriver net.opentabletdriver.OpenTabletDriver && \
+    mkdir -p $HOME/.config/systemd/user && \
     curl -s https://raw.githubusercontent.com/flathub/net.opentabletdriver.OpenTabletDriver/refs/heads/master/scripts/opentabletdriver.service > ~/.config/systemd/user/opentabletdriver.service  && \
     systemctl --user daemon-reload && \
     systemctl enable --user --now opentabletdriver.service

--- a/system_files/shared/usr/lib/systemd/system/usr-share-sddm-themes.mount
+++ b/system_files/shared/usr/lib/systemd/system/usr-share-sddm-themes.mount
@@ -1,0 +1,20 @@
+# Workaround to allow KDE Discover to install sddm themes
+# TODO: Remove this whenever sddm allows installing themes other than in /usr/share.
+# See https://github.com/sddm/sddm/issues/1561
+
+[Unit]
+Description=KDE writable sddm workaround
+RequiresMountsFor=/usr /var
+ConditionPathExists=/usr/share/sddm
+ConditionPathExists=/var/sddm_themes/themes
+ConditionPathExists=/var/sddm_themes/themes.work
+PartOf=aurora-kde-themes-workaround.target
+
+[Mount]
+Type=overlay
+What=overlay
+Where=/usr/share/sddm/themes
+Options=lowerdir=/usr/share/sddm/themes,upperdir=/var/sddm_themes/themes,workdir=/var/sddm_themes/themes.work
+
+[Install]
+WantedBy=multi-user.target

--- a/system_files/shared/usr/lib/tmpfiles.d/usr-share-sddm-themes.conf 
+++ b/system_files/shared/usr/lib/tmpfiles.d/usr-share-sddm-themes.conf 
@@ -1,0 +1,6 @@
+# Workaround to allow KDE Discover to install sddm themes
+# TODO: Remove this whenever sddm allows installing themes other than in /usr/share.
+# See https://github.com/sddm/sddm/issues/1561
+
+d /var/sddm_themes/themes 0755 - - -
+d /var/sddm_themes/themes.work 0755 - - -


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->

add sddm theme workaround from Bazzite.  [mount service](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/kinoite/usr/lib/systemd/system/usr-share-sddm-themes.mountl) , [tmpfiles](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/kinoite/usr/lib/tmpfiles.d/usr-share-sddm-themes.conf).

since i didn't see any issue regarding [sddm fallback to default theme ](https://github.com/ublue-os/bluefin/issues/1988) again on bazzite, i decided to re add this workaround again.

