### PR TITLE
fix: fix hwe builds

### DIFF
--- a/build_files/base/09-hwe-additions.sh
+++ b/build_files/base/09-hwe-additions.sh
@@ -16,11 +16,6 @@ curl --retry 3 -Lo /etc/yum.repos.d/_copr_lukenukem-asus-linux.repo \
 curl --retry 3 -Lo /etc/yum.repos.d/linux-surface.repo \
         https://pkg.surfacelinux.com/fedora/linux-surface.repo
 
-# Asus Firmware
-git clone https://gitlab.com/asus-linux/firmware.git --depth 1 /tmp/asus-firmware
-cp -rf /tmp/asus-firmware/* /usr/lib/firmware/
-rm -rf /tmp/asus-firmware
-
 ASUS_PACKAGES=(
     asusctl
     asusctl-rog-gui


### PR DESCRIPTION
This will remove the unneeded Asus-firmware repo from the HWE builds. These are upstreamed so we will not need these anymore.
