### PR TITLE
feat(ci): add ujust recipe to list installed rpms

### DIFF
--- a/.github/workflows/validate-just.yml
+++ b/.github/workflows/validate-just.yml
@@ -1,0 +1,29 @@
+name: Validate Justfiles
+
+on:
+  pull_request:
+    paths:
+      - "Justfile"
+      - "just/*"
+  push:
+    branches:
+      - main
+    paths:
+      - "Justfile"
+      - "just/*"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Install Just
+        shell: bash
+        run: bash .github/workflows/shared/install-just.sh
+        
+      - name: Check Just Syntax
+        shell: bash
+        run: |
+          just check

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -226,3 +226,10 @@ setup-brew-not-found ACTION="":
         pkexec rm -f "${FILES_TO_BE_REMOVED[@]}"
       echo "Brew command-not-found has been ${b}${red}disabled${n}"
     fi
+
+# List installed RPM packages of currently booted system
+[group('Apps')]
+list-installed-rpms:
+    #!/usr/bin/env bash
+    deployment=$(rpm-ostree status --json | jq '.deployments[] | select(.booted == true) | .checksum' | sed 's/"//g')
+    rpm-ostree db list $deployment


### PR DESCRIPTION
I find myself relearning how to list the packages installed on the currently booted image so I figured that this could be handy to include by default.

I am also adding a GitHub action to validate justfiles.

```bash
❯❯ ujust list-installed-rpms
ostree commit: ebfe7b05027baa70709a82208b18684622f72b5e7a90fbdf7130770ca5f720a6
 ImageMagick-1:7.1.1.41-1.fc41.x86_64
 ImageMagick-libs-1:7.1.1.41-1.fc41.x86_64
 Judy-1.0.5-37.fc41.x86_64
 LibRaw-0.21.3-1.fc41.x86_64
 ModemManager-1.22.0-4.fc41.x86_64
 ModemManager-glib-1.22.0-4.fc41.x86_64
 NetworkManager-1:1.50.0-1.fc41.x86_64
 NetworkManager-bluetooth-1:1.50.0-1.fc41.x86_64
 NetworkManager-config-connectivity-fedora-1:1.50.0-1.fc41.noarch
 NetworkManager-libnm-1:1.50.0-1.fc41.x86_64
 NetworkManager-openconnect-1.2.10-6.fc41.x86_64
 NetworkManager-openvpn-1:1.12.0-2.fc41.x86_64
 NetworkManager-ppp-1:1.50.0-1.fc41.x86_64
 NetworkManager-team-1:1.50.0-1.fc41.x86_64
 NetworkManager-vpnc-1:1.2.8-8.fc41.x86_64
 NetworkManager-wifi-1:1.50.0-1.fc41.x86_64
 NetworkManager-wwan-1:1.50.0-1.fc41.x86_64
 PackageKit-Qt6-1.1.1-6.fc41.x86_64
 PackageKit-glib-1.2.8-8.fc41.x86_64
 SDL2-2.30.11-1.fc41.x86_64
 SDL2_image-2.8.4-1.fc41.x86_64
 SDL2_ttf-2.22.0-3.fc41.x86_64
 SLOF-20220719-5.git6b6c16b4.fc41.noarch
 aardvark-dns-2:1.13.1-1.fc41.x86_64
 abattis-cantarell-fonts-0.301-13.fc41.noarch
 abattis-cantarell-vf-fonts-0.301-13.fc41.noarch
 accounts-qml-module-qt6-0.7^20231216.05e79eb-4.fc41.x86_64
 accountsservice-23.13.9-5.fc41.x86_64

[ ... snip ... ]

 zlib-ng-compat-devel-2.2.3-1.fc41.x86_64
 zram-generator-1.1.2-12.fc41.x86_64
 zram-generator-defaults-1.1.2-12.fc41.noarch
 zsh-5.9-15.fc41.x86_64
 zstd-1.5.6-2.fc41.x86_64
 zvbi-0.2.42-1.fc41.x86_64
 zxing-cpp-2.2.1-2.fc41.x86_64
```