### PR TITLE
fix(nvidia): use correct kernel flavor for akmods with stable-daily

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -130,6 +130,8 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     # AKMODS Flavor and Kernel Version
     if [[ "${flavor}" =~ hwe ]]; then
         akmods_flavor="bazzite"
+    elif [[ "${tag}" =~ stable ]]; then
+        akmods_flavor="coreos-stable"
     elif [[ "${tag}" =~ beta ]]; then
         akmods_flavor="coreos-testing"
     else


### PR DESCRIPTION
A recent refactor of the Justfile accidentally dropped these two lines, which is causing the NVIDIA `stable-daily` images to have mismatched driver / graphics toolkit versions.

This should resolve #148.