### PR TITLE
fix: use libheif from Fedora to support older Intel platforms

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -38,7 +38,7 @@ rm /etc/yum.repos.d/_copr_sentry-switcheroo-control_discrete.repo
 # https://github.com/ublue-os/aurora/issues/8
 rpm-ostree override replace \
     --experimental \
-    --from repo=updates \
+    --from repo=fedora \
         libheif heif-pixbuf-loader
 
 # Starship Shell Prompt

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -33,6 +33,14 @@ rpm-ostree override replace \
 
 rm /etc/yum.repos.d/_copr_sentry-switcheroo-control_discrete.repo
 
+# TODO: Fedora 41 specific -- re-evaluate with Fedora 42
+# negativo's libheif is broken somehow on older Intel machines
+# https://github.com/ublue-os/aurora/issues/8
+rpm-ostree override replace \
+    --experimental \
+    --from repo=updates \
+        libheif heif-pixbuf-loader
+
 # Starship Shell Prompt
 curl --retry 3 -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz"
 tar -xzf /tmp/starship.tar.gz -C /tmp


### PR DESCRIPTION
Some context from Discord:
> @ledif
> - If we use negativo's libheif (current situation), we get better support for HEIF images (what is missing due to patents?) but old Intel hardware crashes
> - If we use Fedora's libheif, we lose some HEIF support (again, not sure what) but older Intel is supported
> ... Maybe we can just override the override directly in Aurora instead of starting a debate in the packages repo about what should be included by default for Bazzite as well

> @castrojo 
> yeah, do it in aurora
> I can almost guarantee bazzite won't turn off heif for people on i915

Related to https://github.com/ublue-os/aurora/issues/8.
