### PR TITLE
chore: Replace solaar with flatpak

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -17,3 +17,4 @@ app/io.missioncenter.MissionCenter/x86_64/stable
 app/org.gnome.DejaDup/x86_64/stable
 app/org.gnome.World.PikaBackup/x86_64/stable
 runtime/org.gtk.Gtk3theme.Breeze/x86_64/3.22
+app/io.github.pwr_solaar.solaar/x86_64/stable

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -26,8 +26,6 @@ sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applica
 sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/htop.desktop
 sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/nvtop.desktop
 
-#Disable autostart behaviour
-rm -f /etc/xdg/autostart/solaar.desktop
 
 # Disable all COPRs and RPM Fusion Repos
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo

--- a/packages.json
+++ b/packages.json
@@ -50,7 +50,6 @@
 				"samba-winbind-modules",
 				"samba",
 				"setools-console",
-				"solaar",
 				"sssd-ad",
 				"sssd-ipa",
 				"sssd-krb5",


### PR DESCRIPTION
Removes the solaar rpm from the base image and adds solaar flatpak
