### PR TITLE
fix: allow wheel users to access yubikeys

### DIFF
--- a/system_files/shared/usr/share/polkit-1/rules.d/99-pcscd.rules
+++ b/system_files/shared/usr/share/polkit-1/rules.d/99-pcscd.rules
@@ -1,0 +1,12 @@
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_card" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_pcsc" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});


### PR DESCRIPTION
Port of https://github.com/ublue-os/bluefin/pull/2163

Closes #163 