### PR TITLE
fix: allow wheel group users to access yubikeys

### DIFF
--- a/system_files/shared/usr/share/polkit-1/rules.d/99-pcscd.rules
+++ b/system_files/shared/usr/share/polkit-1/rules.d/99-pcscd.rules
@@ -1,0 +1,13 @@
+
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_card" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_pcsc" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});

--- a/system_files/shared/usr/share/polkit-1/rules.d/99-pcscd.rules
+++ b/system_files/shared/usr/share/polkit-1/rules.d/99-pcscd.rules
@@ -1,4 +1,3 @@
-
 polkit.addRule(function(action, subject) {
         if (action.id == "org.debian.pcsc-lite.access_card" &&
                 subject.isInGroup("wheel")) {


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->

Porting over the change from Bluefin: 

https://github.com/ublue-os/bluefin/pull/2163

Issue: https://github.com/ublue-os/aurora/issues/163
