### PR TITLE
feat: install new flatpaks for current users on boot

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -215,13 +215,27 @@ configure-vfio ACTION="":
 # Install system flatpaks for rebasers
 [group('System')]
 [private]
-install-system-flatpaks:
+install-system-flatpaks CURR_LIST_FILE="":
     #!/usr/bin/bash
-    IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-    BASE_IMAGE_NAME=$(jq -r '."base-image-name"' < $IMAGE_INFO)
-    FLATPAKS="aurora_flatpaks/flatpaks"
-    FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/aurora/main/${FLATPAKS} | tr '\n' ' ')"
+    CURR_LIST_FILE={{ CURR_LIST_FILE }}
+    IMAGE_NAME=$(jq -r '."image-name"' < "/usr/share/ublue-os/image-info.json")
+    FLATPAK_LIST="$(curl https://raw.githubusercontent.com/ublue-os/aurora/main/aurora_flatpaks/flatpaks | tr '\n' ' ')"
     flatpak --system -y install --or-update ${FLATPAK_LIST}
+
+    if [[ ${IMAGE_NAME} =~ "dx" ]]; then
+        DX_FLATPAKS="$(curl https://raw.githubusercontent.com/ublue-os/aurora/main/dx_flatpaks/flatpaks | tr '\n' ' ')"
+        FLATPAK_LIST="${FLATPAK_LIST} ${DX_FLATPAKS}"
+    fi
+
+    if [[ -n ${CURR_LIST_FILE} ]]; then
+        CURRENT_FLATPAK_LIST=$(cat "${CURR_LIST_FILE} 2>/dev/null")
+        if [[ ${FLATPAK_LIST} != ${CURRENT_FLATPAK_LIST} ]]; then
+            flatpak --system -y install --or-update ${FLATPAK_LIST}
+            echo "${FLATPAK_LIST}" > "${CURR_LIST_FILE}"
+        fi
+    else
+        flatpak --system -y install --or-update ${FLATPAK_LIST}
+    fi
 
 # Configure grub bootmenu visibility
 [group('System')]

--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -229,8 +229,10 @@ install-system-flatpaks CURR_LIST_FILE="":
 
     if [[ -n ${CURR_LIST_FILE} ]]; then
         CURRENT_FLATPAK_LIST=$(cat "${CURR_LIST_FILE} 2>/dev/null")
-        if [[ ${FLATPAK_LIST} != ${CURRENT_FLATPAK_LIST} ]]; then
-            flatpak --system -y install --or-update ${FLATPAK_LIST}
+        # get flatpaks that are in FLATPAK_LIST but not in CURRENT_FLATPAK_LIST
+        NEW_FLATPAKS=$(comm -23 <(sort "${FLATPAK_LIST}") <(sort "${CURRENT_FLATPAK_LIST}"))
+        if [[ -n ${NEW_FLATPAKS} ]]; then
+            flatpak --system -y install --or-update ${NEW_FLATPAKS}
             echo "${FLATPAK_LIST}" > "${CURR_LIST_FILE}"
         fi
     else

--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -2,10 +2,14 @@
 
 # Script Version
 VER=2
-VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/flatpak_manager_version"
+LOCAL_UBLUE_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/ublue"
+VER_FILE="${LOCAL_UBLUE_DIR}/flatpak_manager_version"
 VER_RAN=$(cat "$VER_FILE")
 
-mkdir -p "$(dirname "$VER_FILE")" || exit 1
+mkdir -p "${LOCAL_UBLUE_DIR}" || exit 1
+
+# Install flatpaks if the list has been updated
+ujust install-system-flatpaks CURR_LIST_FILE="${LOCAL_UBLUE_DIR}/flatpak_current_list"
 
 # Run script if updated
 if [[ -f $VER_FILE && $VER = "$VER_RAN" ]]; then


### PR DESCRIPTION
This updates install-system-flatpaks just recipe to allow passing a list of flatpaks, this will be compared with the list of flatpaks in the repo and install new flatpaks when they differ. This is called on boot through ublue-flatpak-manager, which allows keeping flatpaks in sync for current users.

Fixes https://github.com/ublue-os/aurora/issues/147