### PR TITLE
feat: remove inputleap from base image

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -18,3 +18,4 @@ app/org.gnome.DejaDup/x86_64/stable
 app/org.gnome.World.PikaBackup/x86_64/stable
 runtime/org.gtk.Gtk3theme.Breeze/x86_64/3.22
 app/io.github.pwr_solaar.solaar/x86_64/stable
+app/io.github.input_leap.input-leap/x86_64/stable

--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -8,7 +8,6 @@ app/org.kde.kweather/x86_64/stable
 app/org.kde.kclock/x86_64/stable
 app/org.fkoehler.KTailctl/x86_64/stable
 app/org.kde.haruna/x86_64/stable
-app/org.kde.filelight/x86_64/stable
 app/com.github.tchx84.Flatseal/x86_64/stable
 app/io.github.dvlv.boxbuddyrs/x86_64/stable
 app/io.github.flattool.Warehouse/x86_64/stable

--- a/packages.json
+++ b/packages.json
@@ -26,7 +26,6 @@
 				"kcm_ublue",
 				"krb5-workstation",
 				"ifuse",
-				"input-leap",
 				"input-remapper",
 				"jetbrains-mono-fonts-all",
 				"libimobiledevice",

--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Script Version
-VER=2
+VER=3
 LOCAL_UBLUE_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/ublue"
 VER_FILE="${LOCAL_UBLUE_DIR}/flatpak_manager_version"
 VER_RAN=$(cat "$VER_FILE")

--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Script Version
-VER=3
+VER=2
 LOCAL_UBLUE_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/ublue"
 VER_FILE="${LOCAL_UBLUE_DIR}/flatpak_manager_version"
 VER_RAN=$(cat "$VER_FILE")


### PR DESCRIPTION
Removes inputleap package from the image and replaces it with the flatpak version.

Also removes filelight flatpak, as its already part of the image and it works better than the flatpak which need extra perms to work