### PR TITLE
feat: add scx-scheds package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -54,6 +54,7 @@
 				"sssd-krb5",
 				"sssd-nfs-idmap",
 				"stress-ng",
+				"scx-scheds",
 				"tailscale",
 				"tmux",
 				"topgrade",


### PR DESCRIPTION
Adds the scx-scheds package from ublue-os copr as fedora doesn't seem to carry this package

Resolves #177 
