### PR TITLE
fix: make cursor smaller in gtk flatpaks when fractional scaling is enabled

### DIFF
--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -17,6 +17,9 @@ if [[ -f $VER_FILE && $VER = "$VER_RAN" ]]; then
 	exit 0
 fi
 
+# smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
+flatpak override --env=USE_POINTER_VIEWPORT=1
+
 # Set up Firefox default configuration
 mkdir -p /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref
 rm -f /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref/*aurora*.js

--- a/system_files/shared/usr/libexec/ublue-flatpak-manager
+++ b/system_files/shared/usr/libexec/ublue-flatpak-manager
@@ -17,9 +17,6 @@ if [[ -f $VER_FILE && $VER = "$VER_RAN" ]]; then
 	exit 0
 fi
 
-# smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
-flatpak override --env=USE_POINTER_VIEWPORT=1
-
 # Set up Firefox default configuration
 mkdir -p /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref
 rm -f /var/lib/flatpak/extension/org.mozilla.firefox.systemconfig/$(arch)/stable/defaults/pref/*aurora*.js

--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # SCRIPT VERSION
-USER_SETUP_VER=8
+USER_SETUP_VER=9
 USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
 USER_SETUP_VER_RAN=$(cat "$USER_SETUP_VER_FILE")
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
@@ -60,6 +60,9 @@ fi
 # More consistent Qt/GTK themes for Flatpaks
 flatpak override --env=QT_QPA_PLATFORMTHEME=kde
 flatpak override --filesystem=xdg-config/gtk-4.0:ro
+
+# smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
+flatpak override --env=USE_POINTER_VIEWPORT=1
 
 # Handle privileged tasks
 pkexec /usr/libexec/ublue-privileged-user-setup

--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -58,11 +58,11 @@ if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
 fi
 
 # More consistent Qt/GTK themes for Flatpaks
-flatpak override --env=QT_QPA_PLATFORMTHEME=kde
-flatpak override --filesystem=xdg-config/gtk-4.0:ro
+flatpak override --user --env=QT_QPA_PLATFORMTHEME=kde
+flatpak override --user --filesystem=xdg-config/gtk-4.0:ro
 
 # smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
-flatpak override --env=USE_POINTER_VIEWPORT=1
+flatpak override --user --env=USE_POINTER_VIEWPORT=1
 
 # Handle privileged tasks
 pkexec /usr/libexec/ublue-privileged-user-setup


### PR DESCRIPTION
This works with the breeze cursor, ymmv with other cursor themes

Before:
![before](https://github.com/user-attachments/assets/2fd1d98d-b3c4-4e58-9d2b-0bc90d82628b)

After:
![after](https://github.com/user-attachments/assets/615e997a-5a93-49cc-bee8-cecd2416a9de)

