### PR TITLE
feat: change to CachyOS addons repo for scx-scheds package

### DIFF
--- a/build_files/base/02-install-copr-repos.sh
+++ b/build_files/base/02-install-copr-repos.sh
@@ -16,5 +16,8 @@ curl -Lo /etc/yum.repos.d/hardware:razer.repo https://openrazer.github.io/hardwa
 # Enable Nerd fonts repo
 dnf5 -y copr enable che/nerd-fonts
 
+# Enable repo for scx-scheds
+dnf5 -y copr enable bieszczaders/kernel-cachyos-addons
+
 
 echo "::endgroup::"

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -43,12 +43,6 @@ dnf5 -y swap \
     --repo=fedora \
         heif-pixbuf-loader heif-pixbuf-loader
 
-# Make sure the newest scx-scheds is installed
-dnf5 -y swap \
-    --repo=copr:copr.fedorainfracloud.org:bieszczaders:kernel-cachyos-addons \
-        scx-scheds scx-scheds
-
-dnf5 -y copr remove bieszczaders/kernel-cachyos-addons
 
 # Starship Shell Prompt
 curl --retry 3 -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz"

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -43,6 +43,13 @@ dnf5 -y swap \
     --repo=fedora \
         heif-pixbuf-loader heif-pixbuf-loader
 
+# Make sure the newest scx-scheds is installed
+dnf5 -y swap \
+    --repo=copr:copr.fedorainfracloud.org:bieszczaders:/kernel-cachyos-addons \
+        scx-scheds scx-scheds
+
+dnf5 -y copr remove bieszczaders/kernel-cachyos-addons
+
 # Starship Shell Prompt
 curl --retry 3 -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz"
 tar -xzf /tmp/starship.tar.gz -C /tmp

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -45,7 +45,7 @@ dnf5 -y swap \
 
 # Make sure the newest scx-scheds is installed
 dnf5 -y swap \
-    --repo=copr:copr.fedorainfracloud.org:bieszczaders:/kernel-cachyos-addons \
+    --repo=copr:copr.fedorainfracloud.org:bieszczaders:kernel-cachyos-addons \
         scx-scheds scx-scheds
 
 dnf5 -y copr remove bieszczaders/kernel-cachyos-addons

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -36,6 +36,7 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/charm.repo
 dnf5 -y copr disable ublue-os/staging
 dnf5 -y copr disable che/nerd-fonts
 dnf5 -y copr disable phracek/PyCharm
+dnf5 -y copr disable bieszczaders/kernel-cachyos-addons
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo


### PR DESCRIPTION
Install the scx-scheds package from the CachyOS addons copr instead of ublue staging.

CachyOS repo has up to date package for scx-scheds.