### PR TITLE
fix: Justfile to avoid collision with fedora flatpaks

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -226,7 +226,7 @@ install-system-flatpaks CURR_LIST_FILE="":
             # convert arrays to sorted newline-separated strings to compare lists and get new flatpaks
             NEW_FLATPAKS=($(comm -23 <(printf "%s\n" "${FLATPAK_LIST[@]}" | sort) <(printf "%s\n" "${CURRENT_FLATPAK_LIST[@]}" | sort)))
             if [[ ${#NEW_FLATPAKS[@]} -gt 0 ]]; then
-                flatpak --system -y install --or-update "${NEW_FLATPAKS[@]}"
+                flatpak --system -y install --reinstall --or-update "${NEW_FLATPAKS[@]}"
                 printf "%s\n" "${FLATPAK_LIST[@]}" > "${CURR_LIST_FILE}"
                 notify-send "Welcome to Aurora" "New flatpak apps have been installed!" --app-name="Flatpak Manager Service" -u NORMAL
             fi


### PR DESCRIPTION
This very small added flag ensures we don't collide with fedora flatpaks that might be installed by a user and just reinstalls them from scratch from flathub.

Credits go to @Zeglius <3. 
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
