### PR TITLE
feat(just): add aurora-specific changelogs

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -40,5 +40,11 @@ toggle-updates ACTION="prompt":
 alias changelog := changelogs
 
 # Show the changelog
+
 changelogs:
+    #!/usr/bin/bash
+    CONTENT=$(curl -s https://api.github.com/repos/ublue-os/aurora/releases/latest | jq -r '.body')
+      echo "$CONTENT" | glow -
+
+changelogs-fedora:
     rpm-ostree db diff --changelogs


### PR DESCRIPTION
From https://github.com/ublue-os/bluefin/pull/2189

Pulls in aurora specific changelogs and formats them nicely.

changelogs-fedora will pull fedora package changelogs
