### PR TITLE
chore: disable vscode automated updates

### DIFF
--- a/system_files/dx/etc/skel/.config/Code/User/settings.json
+++ b/system_files/dx/etc/skel/.config/Code/User/settings.json
@@ -1,4 +1,5 @@
 {
     "window.titleBarStyle": "custom",
-    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace"
+    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace",
+    "update.mode": "none"
 }


### PR DESCRIPTION
Automated updates aren't useful since updates are handled through the image.  It just creates a pop-up that nobody can do anything with

