### PR TITLE
fix: add 23.08 runtimes for mangohud and gamescope for lutris/heroic

### DIFF
--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -191,9 +191,13 @@ install-gaming-flatpaks:
                                             app/net.lutris.Lutris/x86_64/stable \
                                             app/net.davidotek.pupgui2/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08 \
+                                            # 23.08 needed for Lutris/heroic
+                                            runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.OBSVkCapture/x86_64/24.08 \
                                             runtime/com.obsproject.Studio.Plugin.OBSVkCapture/x86_64/stable \
-                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08
+                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08 \
+                                            # required for Lutris and Heroic
+                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 \
 
 # Set up command-not-found for Homebrew
 [group('Apps')]

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -197,7 +197,7 @@ install-gaming-flatpaks:
                                             runtime/com.obsproject.Studio.Plugin.OBSVkCapture/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08 \
                                             # required for Lutris and Heroic
-                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 \
+                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08
 
 # Set up command-not-found for Homebrew
 [group('Apps')]


### PR DESCRIPTION
Fixes #203 