### PR TITLE
fix: only run ublue user services for human users

### DIFF
--- a/system_files/dx/usr/lib/systemd/user/aurora-dx-user-vscode.service
+++ b/system_files/dx/usr/lib/systemd/user/aurora-dx-user-vscode.service
@@ -2,6 +2,7 @@
 Description=Run 
 Wants=network-online.target
 After=network-online.target ublue-user-setup.service
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/system_files/shared/usr/lib/systemd/user/ublue-flatpak-manager.service
+++ b/system_files/shared/usr/lib/systemd/user/ublue-flatpak-manager.service
@@ -3,6 +3,7 @@ Description=Manage flatpaks
 Documentation=https://github.com/ublue-os/endlish-oesque/issues/10
 Wants=network-online.target
 After=network-online.target
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/system_files/shared/usr/lib/systemd/user/ublue-user-setup.service
+++ b/system_files/shared/usr/lib/systemd/user/ublue-user-setup.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Configure system for current user
+ConditionUser=!@system
 
 [Service]
 Type=simple


### PR DESCRIPTION
We enable our `systemd --user` services for every user. The SDDM greeter run as the `sddm` user, so our `ublue-*` services are started when the login screen is displayed. Furthermore, the `sddm` users has an actual home directory.

```bash
❯ getent passwd sddm
sddm:x:981:977:SDDM Greeter Account:/var/lib/sddm:/usr/sbin/nologin
```

When we look at this directory, we see it has some state related to our ublue services.

```bash
❯ sudo ls -l /var/lib/sddm/.local/share/ublue
total 12
-rw-r--r--. 1 sddm sddm 2 Jan 23 09:58 flatpak_manager_version
-rw-r--r--. 1 sddm sddm 0 Nov 26 09:22 framework-initialized
-rw-r--r--. 1 sddm sddm 2 Feb  8 08:48 user-setup
-rw-r--r--. 1 sddm sddm 2 Nov 26 09:22 vscode-configured
```

## `journalctl` Logs Before

```
Feb 08 08:48:46 systemd[1]: Started user@981.service - User Manager for UID 981.
Feb 08 08:48:46 audit[1]: SERVICE_START pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=user@981 comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Feb 08 08:48:46 systemd[2427]: Starting ublue-flatpak-manager.service - Manage flatpaks...
Feb 08 08:48:46 systemd[1]: Started session-c1.scope - Session c1 of User sddm.

[ ... snip ... ]

Feb 08 08:48:46 systemd[1]: Started user@0.service - User Manager for UID 0.
Feb 08 08:48:46 audit[1]: SERVICE_START pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=user@0 comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Feb 08 08:48:46 systemd[1]: Started session-c2.scope - Session c2 of User root.
Feb 08 08:48:46 systemd[2528]: Starting ublue-flatpak-manager.service - Manage flatpaks...


[ ... snip ... ]

Feb 08 08:48:51 systemd[1]: Started user@1000.service - User Manager for UID 1000.
Feb 08 08:48:51 audit[1]: SERVICE_START pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=user@1000 comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Feb 08 08:48:51 systemd[2840]: Starting ublue-flatpak-manager.service - Manage flatpaks...
Feb 08 08:48:51 systemd[1]: Started session-3.scope - Session 3 of User adam.
```

## `journalctl` Logs After
```
Feb 09 19:21:49 systemd[1]: Started user@981.service - User Manager for UID 981.
Feb 09 19:21:49 audit[1]: SERVICE_START pid=1 uid=0 auid=4294967295 ses=4294967295 subj=system_u:system_r:init_t:s0 msg='unit=user@981 comm="systemd" exe="/usr/lib/systemd/systemd" hostname=? addr=? terminal=? res=success'
Feb 09 19:21:49 systemd[1760]: ublue-flatpak-manager.service - Manage flatpaks was skipped because of an unmet condition check (ConditionUser=!@system).
Feb 09 19:21:49 systemd[1760]: ublue-user-setup.service - Configure system for current user was skipped because of an unmet condition check (ConditionUser=!@system).
Feb 09 19:21:49 systemd[1760]: aurora-dx-user-vscode.service - Run was skipped because of an unmet condition check (ConditionUser=!@system).
Feb 09 19:21:49 systemd[1]: Started session-c1.scope - Session c1 of User sddm.
```