### PR TITLE
feat: bring back kde-welcome

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -160,8 +160,7 @@
 			],
 			"kinoite": [
 				"krfb",
-				"krfb-libs",
-				"plasma-welcome"
+				"krfb-libs"
 			],
 			"dx": []
 		}
@@ -189,10 +188,7 @@
 		},
 		"exclude": {
 			"all": [],
-			"kinoite": [
-				"plasma-welcome",
-				"plasma-welcome-fedora"
-			],
+			"kinoite": [],
 			"dx": []
 		}
 	}


### PR DESCRIPTION
Brings back the kde-welcome screen.

There was talk that this would be nice to have regarding when new plasma versions come out.