### PR TITLE
feat: add nerd fonts fallback to vscode config

### DIFF
--- a/system_files/dx/etc/skel/.config/Code/User/settings.json
+++ b/system_files/dx/etc/skel/.config/Code/User/settings.json
@@ -1,5 +1,5 @@
 {
     "window.titleBarStyle": "custom",
-    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace",
+    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace, 'Symbols Nerd Font Mono'",
     "update.mode": "none"
 }


### PR DESCRIPTION
https://github.com/ublue-os/bluefin/pull/2198

Add nerd font symbols as a fallback font for vscode so users don't have to change to a nerd font if using default fonts.