### PR TITLE
fix: remove flatpak override for QT_QPA_PLATFORM

### DIFF
--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # SCRIPT VERSION
-USER_SETUP_VER=9
+USER_SETUP_VER=10
 USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
 USER_SETUP_VER_RAN=$(cat "$USER_SETUP_VER_FILE")
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
@@ -58,8 +58,13 @@ if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
 fi
 
 # More consistent Qt/GTK themes for Flatpaks
-flatpak override --user --env=QT_QPA_PLATFORMTHEME=kde
 flatpak override --user --filesystem=xdg-config/gtk-4.0:ro
+
+# TODO: re-evaluate with Fedora 42
+# Setting this variable to anything other than `xdgdesktopportal`
+# will break the XDG Desktop Portal inside the sandbox
+# See https://github.com/ublue-os/aurora/issues/224
+flatpak override --user --unset-env=QT_QPA_PLATFORMTHEME
 
 # smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
 flatpak override --user --env=USE_POINTER_VIEWPORT=1


### PR DESCRIPTION
Setting `QT_QPA_PLATFORMTHEME=kde` for Flatpaks that don't allow filesystem access apparently breaks XDG Desktop Portal support.

Verified in a VM that this variable is unset when running Flatpaks. The file picker is now correctly using the XDG Portal picker instead of the sandboxed KDE picker.

```
❯ flatpak override --user --show
[Context]
filesystems=xdg-config/gtk-4.0:ro;
unset-environment=QT_QPA_PLATFORMTHEME;

[Environment]
QT_QPA_PLATFORMTHEME=
USE_POINTER_VIEWPORT=1

```

Closes https://github.com/ublue-os/aurora/issues/224.