### PR TITLE
chore: remove alternatives workaround

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -4,11 +4,6 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
-# alternatives cannot create symlinks on its own during a container build
-if [[ -f "/usr/bin/ld.bfd" ]]; then
-    ln -sf /usr/bin/ld.bfd /etc/alternatives/ld && ln -sf /etc/alternatives/ld /usr/bin/ld
-fi
-
 ## Pins and Overrides
 ## Use this section to pin packages in order to avoid regressions
 # Remember to leave a note with rationale/link to issue for each pin!

--- a/build_files/shared/build-base.sh
+++ b/build_files/shared/build-base.sh
@@ -22,9 +22,6 @@ if [ "${FEDORA_MAJOR_VERSION}" -lt 41 ]; then
     rpm-ostree install --idempotent dnf5 dnf5-plugins
 fi
 
-# Make Alternatives Directory
-mkdir -p /var/lib/alternatives
-
 # Copy Files to Container
 cp -r /ctx/just /tmp/just
 cp /ctx/packages.json /tmp/packages.json
@@ -75,10 +72,8 @@ echo "::endgroup::"
 
 # Clean Up
 echo "::group:: Cleanup"
-mv /var/lib/alternatives /staged-alternatives
 /ctx/build_files/shared/clean-stage.sh
-mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives &&
-    mkdir -p /var/tmp &&
+mkdir -p /var/tmp &&
     chmod -R 1777 /var/tmp
 ostree container commit
 echo "::endgroup::"

--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -1,10 +1,7 @@
 #!/usr/bin/bash
 
 set -eou pipefail
-
 echo "::group:: Copy Files"
-# Make Alternatives Directory
-mkdir -p /var/lib/alternatives
 
 # Copy Files to Image
 cp /ctx/packages.json /tmp/packages.json
@@ -37,9 +34,7 @@ echo "Variant=Developer Experience" >> /usr/share/kde-settings/kde-profile/defau
 
 # Clean Up
 echo "::group:: Cleanup"
-mv /var/lib/alternatives /staged-alternatives
 /ctx/build_files/shared/clean-stage.sh
-mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives && \
 mkdir -p /var/tmp && \
 chmod -R 1777 /var/tmp
 ostree container commit


### PR DESCRIPTION
Ported from https://github.com/ublue-os/bluefin/pull/2215/

main has removed the workaround since upstream should have fixed it.

Relates: https://github.com/ublue-os/main/pull/721