### PR TITLE
fix: remove un-needed comments from gaming flatpak install recipe

### DIFF
--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -180,6 +180,8 @@ install-k8s-dev-tools:
     echo "Adding Kubernetes command line tools..."
     brew bundle --file /usr/share/ublue-os/homebrew/kubernetes.Brewfile
 
+# Install gaming flatpaks
+# 23.08 runtime versions are needed for Heroic/Lutris
 [group('Apps')]
 install-gaming-flatpaks:
     #!/usr/bin/env bash

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -190,12 +190,10 @@ install-gaming-flatpaks:
                                             app/net.davidotek.pupgui2/x86_64/stable \
                                             app/com.dec05eba.gpu_screen_recorder/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08 \
-                                            # 23.08 needed for Lutris/heroic
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.OBSVkCapture/x86_64/24.08 \
                                             runtime/com.obsproject.Studio.Plugin.OBSVkCapture/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08 \
-                                            # required for Lutris and Heroic
                                             runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08
 
 # Set up command-not-found for Homebrew


### PR DESCRIPTION
The gaming flatpak installation ujust recipe had comment lines that are unneccasary and break the command chain
