### PR TITLE
feat: add desktop entry for boot into windows easily

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -77,7 +77,7 @@ sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:{cu
 ```
 
 ### Documentation
-Be sure to read the [documentation](https://docs.projectbluefin.io/) for more information
+Be sure to read the [documentation](https://docs.getaurora.dev/) for more information
 on how to use your cloud native system.
 """
 HANDWRITTEN_PLACEHOLDER = """\

--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -305,3 +305,11 @@ toggle-tailscale:
             fi
         fi
     fi
+
+
+# Configure Boot to Windows desktop entry
+[group('System')]
+configure-boot-to-windows:
+    mkdir -p $HOME/.local/share/applications
+    cp -r /usr/share/applications/boot-to-windows.desktop $HOME/.local/share/applications
+    sed -i 's/Hidden=true/Hidden=false/' $HOME/.local/share/applications/boot-to-windows.desktop

--- a/system_files/kinoite/usr/bin/boot-to-windows
+++ b/system_files/kinoite/usr/bin/boot-to-windows
@@ -1,0 +1,13 @@
+#!/usr/bin/bash
+
+# Look up the boot number for Windows in the EFI records
+boot_number=$(echo $(efibootmgr) | grep -Po "(?<=Boot)\S{4}(?=( |\* )Windows)")
+
+# Check that Windows EFI entry was found
+if [ -z "$boot_number" ]; then
+    echo "Cannot find Windows boot in EFI, exiting"
+    exit 1
+fi
+
+# Set next boot to be Windows and reboot the machine
+sudo efibootmgr -n "${boot_number}" && reboot

--- a/system_files/kinoite/usr/bin/boot-to-windows
+++ b/system_files/kinoite/usr/bin/boot-to-windows
@@ -5,7 +5,7 @@ boot_number=$(echo $(efibootmgr) | grep -Po "(?<=Boot)\S{4}(?=( |\* )Windows)")
 
 # Check that Windows EFI entry was found
 if [ -z "$boot_number" ]; then
-    echo "Cannot find Windows boot in EFI, exiting"
+    kdialog --error "Cannot find Windows boot in EFI, exiting"
     exit 1
 fi
 

--- a/system_files/kinoite/usr/share/applications/boot-to-windows.desktop
+++ b/system_files/kinoite/usr/share/applications/boot-to-windows.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Boot to Windows
+Comment=Boot to Windows installation
+Type=Application
+Terminal=false
+Icon=folder-windows-symbolic
+Exec=sh -c "pkexec /usr/bin/boot-to-windows"
+Categories=Utility;

--- a/system_files/kinoite/usr/share/applications/boot-to-windows.desktop
+++ b/system_files/kinoite/usr/share/applications/boot-to-windows.desktop
@@ -1,4 +1,5 @@
 [Desktop Entry]
+Hidden=true
 Name=Boot to Windows
 Comment=Boot to Windows installation
 Type=Application


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->

add boot-windows script from [bazzite](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/bin/boot-windows), need better logo tbh, and small changes to changelogs generator.

inspired by this [blogpost](https://web.archive.org/web/20220522051320/https://www.ahoneycutt.me/blog/systemd-boot/).