### PR TITLE
fix: update package list to only include symbol nerd fonts

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -43,7 +43,7 @@
 				"lm_sensors",
 				"make",
 				"mesa-libGLU",
-				"nerd-fonts",
+				"nerdfontssymbolsonly-nerd-fonts",
 				"oddjob-mkhomedir",
 				"opendyslexic-fonts",
 				"openrazer-daemon",


### PR DESCRIPTION
This fixes mutliple reports of the iso size increasing by a lot because nerd fonts pull in about 1 gigabyte worth of data from the terra repo.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
