### PR TITLE
chore: install fira code, monaspace and starship from terra packages

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -43,9 +43,6 @@ dnf5 -y swap \
 
 
 # Starship Shell Prompt
-curl --retry 3 -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz"
-tar -xzf /tmp/starship.tar.gz -C /tmp
-install -c -m 0755 /tmp/starship /usr/bin
 # shellcheck disable=SC2016
 echo 'eval "$(starship init bash)"' >> /etc/bashrc
 

--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -30,12 +30,6 @@ cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.
 
 rm -f /etc/profile.d/gnome-ssh-askpass.{csh,sh} # This shouldn't be pulled in
 
-# Get Default Font since font fallback doesn't work
-curl --retry 3 --output-dir /tmp -LO https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/FiraCode.zip
-mkdir -p /usr/share/fonts/fira-nf
-unzip /tmp/FiraCode.zip -d /usr/share/fonts/fira-nf
-fc-cache -f /usr/share/fonts/fira-nf
-
 # Test aurora gschema override for errors. If there are no errors, proceed with compiling aurora gschema, which includes setting overrides.
 mkdir -p /tmp/aurora-schema-test
 find /usr/share/glib-2.0/schemas/ -type f ! -name "*.gschema.override" -exec cp {} /tmp/aurora-schema-test/ \;

--- a/build_files/dx/04-override-install-dx.sh
+++ b/build_files/dx/04-override-install-dx.sh
@@ -8,16 +8,4 @@ curl --retry 3 -Lo /tmp/kind "https://github.com/kubernetes-sigs/kind/releases/l
 chmod +x /tmp/kind
 mv /tmp/kind /usr/bin/kind
 
-# GitHub Monaspace Font
-DOWNLOAD_URL=$(curl --retry 3 https://api.github.com/repos/githubnext/monaspace/releases/latest | jq -r '.assets[] | select(.name| test(".*.zip$")).browser_download_url')
-curl --retry 3 -Lo /tmp/monaspace-font.zip "$DOWNLOAD_URL"
-
-unzip -qo /tmp/monaspace-font.zip -d /tmp/monaspace-font
-mkdir -p /usr/share/fonts/monaspace
-mv /tmp/monaspace-font/monaspace-v*/fonts/variable/* /usr/share/fonts/monaspace/
-rm -rf /tmp/monaspace-font*
-
-fc-cache -f /usr/share/fonts/monaspace
-fc-cache --system-only --really-force --verbose
-
 echo "::endgroup::"

--- a/packages.json
+++ b/packages.json
@@ -29,6 +29,7 @@
 				"fcitx5-mozc",
 				"fcitx5-chinese-addons",
 				"fcitx5-hangul",
+				"firacode-nerd-fonts",
 				"kcm-fcitx5",
 				"kde-runtime-docs",
 				"kdenetwork-filesharing",

--- a/packages.json
+++ b/packages.json
@@ -68,6 +68,7 @@
 				"sssd-ipa",
 				"sssd-krb5",
 				"sssd-nfs-idmap",
+				"starship",
 				"stress-ng",
 				"scx-scheds",
 				"tailscale",

--- a/packages.json
+++ b/packages.json
@@ -121,6 +121,7 @@
 				"libvirt-nss",
 				"intel-one-mono-fonts",
 				"lxc",
+				"monaspace-nerd-fonts",
 				"mozilla-fira-mono-fonts",
 				"nicstat",
 				"numactl",


### PR DESCRIPTION
This uses the Terra repo to install software that we were curling up until now.