### PR TITLE
chore: unpin kernel on latest and hwe streams

### DIFF
--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -26,7 +26,7 @@ jobs:
       image_flavors: '["hwe", "hwe-nvidia", "hwe-nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
-      kernel_pin: 6.12.12-207.bazzite.fc41.x86_64
+      #kernel_pin: 6.12.12-207.bazzite.fc41.x86_64
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -26,7 +26,7 @@ jobs:
       image_flavors: '["main", "nvidia", "nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
-      kernel_pin: 6.12.15-200.fc41.x86_64
+      #kernel_pin: 6.12.15-200.fc41.x86_64
 
   generate-release:
     name: Generate Release


### PR DESCRIPTION
Unpins the latest and hwe streams kernel

Once kernel-cache has the new 6.13.5 kernel this can be merged