### PR TITLE
feat: expand recipe to rollback broken NVIDIA images

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -877,8 +877,8 @@ tag-images image_name="" default_tag="" tags="":
 #
 # Need to generate a PAT with package write access (https://github.com/settings/tokens)
 # Set $GITHUB_USERNAME and $GITHUB_PAT variables
-
 # Retag images on GHCR
+
 # stream is latest or stable-daily
 [group('Admin')]
 retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
@@ -890,5 +890,5 @@ retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
         skopeo="skopeo"
     fi
     for image in aurora-nvidia-open aurora-nvidia aurora-dx-nvidia aurora-dx-nvidia-open; do
-      $skopeo copy docker://ghcr.io/ublue-os/${image}:{{ working_tag }} docker://ghcr.io/ublue-os/${image}:{{stream}}
+      $skopeo copy docker://ghcr.io/ublue-os/${image}:{{ working_tag }} docker://ghcr.io/ublue-os/${image}:{{ stream }}
     done

--- a/Justfile
+++ b/Justfile
@@ -871,16 +871,17 @@ tag-images image_name="" default_tag="" tags="":
     # Show Images
     ${PODMAN} images
 
-# TODO: generalize this
-# Used on Jan 28 2025 to fix NVIDIA regression
+# Log of uses:
 #   > just retag-stable-daily-nvidia-on-ghcr stable-daily-41.20250126.3 0
+#   > just retag-nvidia-on-ghcr latest latest-41.20250228.1 0
 #
 # Need to generate a PAT with package write access (https://github.com/settings/tokens)
 # Set $GITHUB_USERNAME and $GITHUB_PAT variables
 
 # Retag images on GHCR
+# stream is latest or stable-daily
 [group('Admin')]
-retag-stable-daily-nvidia-on-ghcr working_tag="" dry_run="1":
+retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
     #!/bin/bash
     set -euxo pipefail
     skopeo="echo === skopeo"
@@ -889,5 +890,5 @@ retag-stable-daily-nvidia-on-ghcr working_tag="" dry_run="1":
         skopeo="skopeo"
     fi
     for image in aurora-nvidia-open aurora-nvidia aurora-dx-nvidia aurora-dx-nvidia-open; do
-      $skopeo copy docker://ghcr.io/ublue-os/${image}:{{ working_tag }} docker://ghcr.io/ublue-os/${image}:stable-daily
+      $skopeo copy docker://ghcr.io/ublue-os/${image}:{{ working_tag }} docker://ghcr.io/ublue-os/${image}:{{stream}}
     done

--- a/Justfile
+++ b/Justfile
@@ -871,15 +871,18 @@ tag-images image_name="" default_tag="" tags="":
     # Show Images
     ${PODMAN} images
 
-# Log of uses:
-#   > just retag-stable-daily-nvidia-on-ghcr stable-daily-41.20250126.3 0
+# # Examples:
+#   > just retag-nvidia-on-ghcr stable-daily stable-daily-41.20250126.3 0
 #   > just retag-nvidia-on-ghcr latest latest-41.20250228.1 0
 #
-# Need to generate a PAT with package write access (https://github.com/settings/tokens)
-# Set $GITHUB_USERNAME and $GITHUB_PAT variables
-# Retag images on GHCR
+# working_tag: The tag of the most recent known good image (e.g., stable-daily-41.20250126.3)
+# stream:      One of latest, stable-daily, stable or gts
+# dry_run:     Only print the skopeo commands instead of running them
+#
+# First generate a PAT with package write access (https://github.com/settings/tokens)
+# and set $GITHUB_USERNAME and $GITHUB_PAT environment variables
 
-# stream is latest or stable-daily
+# Retag images on GHCR
 [group('Admin')]
 retag-nvidia-on-ghcr working_tag="" stream="" dry_run="1":
     #!/bin/bash


### PR DESCRIPTION
This was used today to rollback the `latest` tag, which was broken this time instead of `stable-daily`. These changes give us the ability to quickly roll these things back.