### PR TITLE
chore: Terra kf6-kio rename to kf6-kio.switcheroo

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -6,9 +6,9 @@ set -eoux pipefail
 
 
 # Patched shell
-dnf5 -y swap \
-  --repo=terra-extras \
-        kf6-kio kf6-kio.switcheroo
+#dnf5 -y swap \
+#  --repo=terra-extras \
+#        kf6-kio kf6-kio.switcheroo
 
 
 # Make sure KDE Frameworks and our kf6-kio are on the same version

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -8,7 +8,7 @@ set -eoux pipefail
 # Patched shell
 dnf5 -y swap \
   --repo=terra-extras \
-        kf6-kio kf6-kio
+        kf6-kio kf6-kio.switcheroo
 
 
 # Make sure KDE Frameworks and our kf6-kio are on the same version

--- a/packages.json
+++ b/packages.json
@@ -38,6 +38,7 @@
 				"kdenetwork-filesharing",
 				"kdeplasma-addons",
 				"kdialog",
+				"kf6-kio.switcheroo",
 				"ksystemlog",
 				"input-remapper",
 				"jetbrains-mono-fonts-all",


### PR DESCRIPTION
Terra is planning on renaming the kf6-kio package to kio-kf6.switcheroo

Just a draft for now, merge if/when Terra renames the package