### PR TITLE
fix: downgrade dnf5 to 5.2.10 to workaround pulling signing keys

### DIFF
--- a/build_files/shared/build-base.sh
+++ b/build_files/shared/build-base.sh
@@ -6,6 +6,7 @@ echo "::group:: ===Install dnf5==="
 if [ "${FEDORA_MAJOR_VERSION}" -lt 41 ]; then
     rpm-ostree install --idempotent dnf5 dnf5-plugins
 fi
+dnf5 -y downgrade dnf5
 
 # Copy Files to Container
 cp -r /ctx/just /tmp/just


### PR DESCRIPTION
Fixes build, should be reverted whenever https://github.com/rpm-software-management/dnf5/issues/2134 is fixed upstream
