### PR TITLE
feat: tell discover to only show flatpaks

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -28,6 +28,9 @@ sed -i 's@Exec=ptyxis@Exec=kde-ptyxis@g' /usr/share/applications/org.gnome.Ptyxi
 sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop
 cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
 
+# Plasma Discover
+sed -i 's|^Exec=plasma-discover %F$|Exec=plasma-discover --backends flatpak-backend %F|' /usr/share/applications/org.kde.discover.desktop
+
 rm -f /etc/profile.d/gnome-ssh-askpass.{csh,sh} # This shouldn't be pulled in
 
 # Test aurora gschema override for errors. If there are no errors, proceed with compiling aurora gschema, which includes setting overrides.


### PR DESCRIPTION
This adds a one-line change to the build files that will alter the Discover Desktop Shortcut with a command-line argument so that it only shows Flatpaks instead of Flatpaks, Themes and other stuff.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
