### PR TITLE
fix: rename kf6-kio package

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -7,18 +7,8 @@ set -eoux pipefail
 
 # Patched shell
 dnf5 -y swap \
-  --repo=terra-extras \
-        kf6-kio kf6-kio
-
-
-# Make sure KDE Frameworks and our kf6-kio are on the same version
-kf6_version=$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}')
-kf6_kio_version=$(rpm -qi kf6-kio-core | awk '/^Version/ {print $3}')
-
-if [[ "$kf6_version" != "$kf6_kio_version" ]]; then
-    echo "Mismatched kf6-kio version $kf6_kio_version. Check Terra's kf6-kio for $kf6_version"
-    exit 1
-fi
+    --repo=terra-extras \
+        kf6-kio kf6-kio.switcheroo-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}')
 
 # Fix for ID in fwupd
 dnf5 -y swap \


### PR DESCRIPTION
This renames the patched kf6-kio to match Terra's naming, it also simplifies version matching.

Fixes build.