### PR TITLE
fix: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @NiHaiden
-* @RealVishy
-* @ledif
-* @inffy
+* @NiHaiden @RealVishy @ledif @inffy


### PR DESCRIPTION
Our CODEOWNERS file was not properly set, so it only added the last approver (me) to new pull requests

Github docs https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax

> If you want to match two or more code owners with the same pattern, all the code owners must be on the same line. If the code owners are not on the same line, the pattern matches only the last mentioned code owner.
