### PR TITLE
Revert "fix: downgrade dnf5 to 5.2.10 to workaround pulling signing k…

### DIFF
--- a/build_files/shared/build-base.sh
+++ b/build_files/shared/build-base.sh
@@ -6,7 +6,6 @@ echo "::group:: ===Install dnf5==="
 if [ "${FEDORA_MAJOR_VERSION}" -lt 41 ]; then
     rpm-ostree install --idempotent dnf5 dnf5-plugins
 fi
-dnf5 -y downgrade dnf5
 
 # Copy Files to Container
 cp -r /ctx/just /tmp/just


### PR DESCRIPTION
…eys (#274)"

This reverts commit 2816a425e9f4ba9177cd9085cc53f38bc28f17d4.

Once https://github.com/rpm-software-management/dnf5/pull/2141 is released this can be merged
