### PR TITLE
chore: remove fw-fanctrl

### DIFF
--- a/build_files/base/02-install-copr-repos.sh
+++ b/build_files/base/02-install-copr-repos.sh
@@ -19,5 +19,4 @@ dnf5 -y copr enable bieszczaders/kernel-cachyos-addons
 # Enable Terra repo
 dnf5 -y install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release{,-extras}
 
-
 echo "::endgroup::"

--- a/build_files/base/02-install-copr-repos.sh
+++ b/build_files/base/02-install-copr-repos.sh
@@ -16,9 +16,6 @@ dnf5 -y config-manager addrepo --from-repofile=https://openrazer.github.io/hardw
 # Enable repo for scx-scheds
 dnf5 -y copr enable bieszczaders/kernel-cachyos-addons
 
-# Enable fw-fanctrl repo
-dnf5 -y copr enable tulilirockz/fw-fanctrl
-
 # Enable Terra repo
 dnf5 -y install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release{,-extras}
 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -31,7 +31,6 @@ dnf5 -y swap \
     --repo=fedora \
         heif-pixbuf-loader heif-pixbuf-loader
 
-
 # Starship Shell Prompt
 # shellcheck disable=SC2016
 echo 'eval "$(starship init bash)"' >> /etc/bashrc

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -41,7 +41,6 @@ dnf5 -y copr disable ublue-os/staging
 dnf5 -y copr disable ublue-os/packages
 dnf5 -y copr disable phracek/PyCharm
 dnf5 -y copr disable bieszczaders/kernel-cachyos-addons
-dnf5 -y copr disable tulilirockz/fw-fanctrl
 
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo

--- a/packages.json
+++ b/packages.json
@@ -17,7 +17,6 @@
 				"foo2zjs",
 				"freeipa-client",
 				"fuse-encfs",
-				"fw-fanctrl",
 				"gcc",
 				"git-credential-libsecret",
 				"glow",


### PR DESCRIPTION
Cleanup before F42 betas

This doesn't have f42 packages atleast at this moment and propably not really used anyway

Already talked with tulip if this could be brought to ublue-os copr