### PR TITLE
chore: remove wl akmod

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -44,7 +44,6 @@ dnf5 -y install \
     https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
     https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
 dnf5 -y install \
-    broadcom-wl /tmp/akmods/kmods/*wl*.rpm \
     v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
 dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
 


### PR DESCRIPTION
Some cleanup before F42 beta starts

This isn't shipped by fedora (atleast anymore) so we shouldn't diverge too much. 

Bluefin also doesn't carry this.

If someone for some reason needs this, they can propably do https://github.com/p1u3o/tidbits?tab=readme-ov-file#broadcom

