### PR TITLE
chore: remove hidden system-flatpak-install from the ujust list

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -221,7 +221,6 @@ configure-vfio ACTION="":
 
 # Install system flatpaks for rebasers
 [group('System')]
-[private]
 install-system-flatpaks CURR_LIST_FILE="":
     #!/usr/bin/env bash
     CURR_LIST_FILE={{ CURR_LIST_FILE }}


### PR DESCRIPTION
I don't think this should be hidden nowadays anymore

