### PR TITLE
chore: enable openrazer kernel module for Fedora 42

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -40,10 +40,11 @@ AKMODS=(
     /tmp/akmods/kmods/*xone*.rpm
     /tmp/akmods/kmods/*xpadneo*.rpm
     /tmp/akmods/kmods/*framework-laptop*.rpm
+    /tmp/akmods/kmods/*openrazer*.rpm
 )
-if [[ "${UBLUE_IMAGE_TAG}" != "beta" ]]; then
-    AKMODS+=(/tmp/akmods/kmods/*openrazer*.rpm)
-fi
+# if [[ "${UBLUE_IMAGE_TAG}" != "beta" ]]; then
+#     AKMODS+=(/tmp/akmods/kmods/*openrazer*.rpm)
+# fi
 dnf5 -y install "${AKMODS[@]}"
 
 # RPMFUSION Dependent AKMODS

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -42,9 +42,6 @@ AKMODS=(
     /tmp/akmods/kmods/*framework-laptop*.rpm
     /tmp/akmods/kmods/*openrazer*.rpm
 )
-# if [[ "${UBLUE_IMAGE_TAG}" != "beta" ]]; then
-#     AKMODS+=(/tmp/akmods/kmods/*openrazer*.rpm)
-# fi
 dnf5 -y install "${AKMODS[@]}"
 
 # RPMFUSION Dependent AKMODS


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->

Fedora 42 is now [available](https://download.opensuse.org/repositories/hardware:/razer/Fedora_42/) for openrazer-daemon