### PR TITLE
feat: remove rpmfusion and replace v4l2loopback from terra

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -49,6 +49,9 @@ else
         /tmp/akmods/kmods/*framework-laptop*.rpm
 fi
 
+# Install v4l2loopback from terra or gracefully fail
+dnf5 -y install --repo="terra*" /tmp/akmods/kmods/*v4l2loopback*.rpm || true
+
 # Nvidia AKMODS
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
   # Fetch Nvidia RPMs

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -50,7 +50,7 @@ else
 fi
 
 # Install v4l2loopback from terra or gracefully fail
-dnf5 -y install --repo="terra*" /tmp/akmods/kmods/*v4l2loopback*.rpm || true
+dnf5 -y install --repo="terra" /tmp/akmods/kmods/*v4l2loopback*.rpm || true
 
 # Nvidia AKMODS
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -49,34 +49,6 @@ else
         /tmp/akmods/kmods/*framework-laptop*.rpm
 fi
 
-# RPMFUSION Dependent AKMODS
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y install \
-        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm || true
-    dnf5 -y install \
-        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm || true
-else
-    dnf5 -y install \
-        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
-        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
-fi
-
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y install \
-        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm || true
-else
-    dnf5 -y install \
-        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
-fi
-
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y remove rpmfusion-free-release || true
-    dnf5 -y remove rpmfusion-nonfree-release || true
-else
-    dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
-fi
-
-
 # Nvidia AKMODS
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
   # Fetch Nvidia RPMs


### PR DESCRIPTION
PipeWire should now provide the features which previously made v4l2loopback necessary. This removes the v4l2loopback install.

Additionally, this removes rpmfusion and installs v4l2loopback from terra

Picked from https://github.com/ublue-os/bluefin/pull/2330

