### PR TITLE
feat(cli): Add LACT to install-gaming-flatpaks ujust command

### DIFF
--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -191,6 +191,7 @@ install-gaming-flatpaks:
                                             app/net.lutris.Lutris/x86_64/stable \
                                             app/net.davidotek.pupgui2/x86_64/stable \
                                             app/com.dec05eba.gpu_screen_recorder/x86_64/stable \
+                                            app/io.github.ilya_zlobintsev.LACT/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.OBSVkCapture/x86_64/24.08 \


### PR DESCRIPTION
Due to the *very* recent addition of LACT to the Flathub repository, I decided to make this PR to add it to the `ujust install-gaming-flatpaks` command for people who wish to overclock/underclock their GPU to make it achieve their desired level of power for gaming.
