### PR TITLE
chore: remove topgrade

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -73,7 +73,6 @@
 				"starship",
 				"tailscale",
 				"tmux",
-				"topgrade",
 				"ublue-bling",
 				"ublue-brew",
 				"ublue-fastfetch",


### PR DESCRIPTION
Remove topgrade from this cycle. It is available from brew.


