### PR TITLE
fix: add default terminal font back to image

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -19,6 +19,7 @@
 				"fcitx5-mozc",
 				"fcitx5-sayura",
 				"fcitx5-unikey",
+ 				"firacode-nerd-fonts",
 				"firewall-config",
 				"fish",
 				"foo2zjs",


### PR DESCRIPTION
This font was removed in #319 but it is the default terminal font, so we should keep it on the image.