### PR TITLE
feat(dx): add devtoolbox and DevPod flatpaks to -dx

### DIFF
--- a/dx_flatpaks/flatpaks
+++ b/dx_flatpaks/flatpaks
@@ -1,2 +1,4 @@
 app/io.podman_desktop.PodmanDesktop/x86_64/stable
 app/io.github.getnf.embellish/x86_64/stable
+app/me.iepure.devtoolbox/x86_64/stable
+app/sh.loft.Devpod/x86_64/stable


### PR DESCRIPTION
DevPod isn't yet published in flathub but its pretty much waiting for approval review

EDIT: It should be available in "4-5 hours"