### PR TITLE
fix: rename kf6-kio package on terra

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -7,7 +7,7 @@ set -eoux pipefail
 # Patched shell and switcheroo-control
   dnf5 -y swap \
       --repo="terra*" \
-          kf6-kio kf6-kio.switcheroo-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}')
+          kf6-kio kf6-kio-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}')
   dnf5 -y swap \
       --repo="terra*" \
           switcheroo-control switcheroo-control

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -6,10 +6,10 @@ set -eoux pipefail
 
 # Patched shell and switcheroo-control
   dnf5 -y swap \
-      --repo="terra*" \
+      --repo="terra-extras" \
           kf6-kio kf6-kio-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}')
   dnf5 -y swap \
-      --repo="terra*" \
+      --repo="terra-extras" \
           switcheroo-control switcheroo-control
 
 # Fix for ID in fwupd


### PR DESCRIPTION
Terra is removing the -switcheroo tag from kf6-kio

Propably needs to be force merged thanks to HWE :)