### PR TITLE
feat: bring back fw-fanctrl for f42

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -189,7 +189,8 @@
 		"include": {
 			"all": [
         			"google-noto-fonts-all",
-        			"uupd"
+        			"uupd",
+				"fw-fanctrl"
       		],
 			"dx": []
 		},


### PR DESCRIPTION
Adds back the fw-fanctrl package from ublue copr for fedora 42 only


