### PR TITLE
fix: add correct name for devpod  flatpak

### DIFF
--- a/dx_flatpaks/flatpaks
+++ b/dx_flatpaks/flatpaks
@@ -1,4 +1,4 @@
 app/io.podman_desktop.PodmanDesktop/x86_64/stable
 app/io.github.getnf.embellish/x86_64/stable
 app/me.iepure.devtoolbox/x86_64/stable
-app/sh.loft.Devpod/x86_64/stable
+app/sh.loft.devpod/x86_64/stable


### PR DESCRIPTION
the devpod flatpak name was incorrectly set with capital D
