### PR TITLE
chore: disable building HWE for now

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -14,9 +14,10 @@ jobs:
     build-image-latest-main:
         uses: ./.github/workflows/build-image-latest-main.yml
         secrets: inherit
-    build-image-latest-hwe:
-        uses: ./.github/workflows/build-image-latest-hwe.yml
-        secrets: inherit
+   # Disable HWE for the time being
+   # build-image-latest-hwe:
+   #     uses: ./.github/workflows/build-image-latest-hwe.yml
+   #     secrets: inherit
     build-image-beta:
         uses: ./.github/workflows/build-image-beta.yml
         secrets: inherit


### PR DESCRIPTION
As HWE is currently broken because of surface stuff, disable these for the time being


