### PR TITLE
feat: enable sunshine + add ujust script

### DIFF
--- a/build_files/base/02-install-copr-repos.sh
+++ b/build_files/base/02-install-copr-repos.sh
@@ -19,4 +19,7 @@ dnf5 -y copr enable bieszczaders/kernel-cachyos-addons
 # Enable Terra repo
 dnf5 -y install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release{,-extras}
 
+# Enable sunshine repo
+dnf5 -y copr enable lizardbyte/beta
+
 echo "::endgroup::"

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -52,6 +52,7 @@ dnf5 -y copr disable ublue-os/staging
 dnf5 -y copr disable ublue-os/packages
 dnf5 -y copr disable phracek/PyCharm
 dnf5 -y copr disable bieszczaders/kernel-cachyos-addons
+dnf5 -y copr disable lizardbyte/beta
 
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -20,6 +20,9 @@ systemctl --global enable ublue-user-setup.service
 systemctl --global enable podman-auto-update.timer
 systemctl enable check-sb-key.service
 
+# disable sunshine service
+systemctl --global disable sunshine.service
+
 # Updater
 if systemctl cat -- uupd.timer &> /dev/null; then
     systemctl enable uupd.timer

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -256,3 +256,31 @@ list-installed-rpms:
     #!/usr/bin/env bash
     deployment=$(rpm-ostree status --json | jq '.deployments[] | select(.booted == true) | .checksum' | sed 's/"//g')
     rpm-ostree db list $deployment
+
+# Setup and configure Sunshine Game Streaming host
+[group('Apps')]
+setup-sunshine ACTION="":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    SERVICE_STATE="$(systemctl is-enabled --user sunshine.service)"
+    OPTION={{ ACTION }}
+    if [ "$SERVICE_STATE" == "enabled" ]; then
+        SERVICE_STATE="${green}${b}Enabled${n}"
+    else
+        SERVICE_STATE="${red}${b}Disabled${n}"
+    fi
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust setup-sunshine <option>"
+      echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'enable' to enable the Sunshine service"
+      echo "  Use 'disable' to disable the Sunshine service"
+      exit 0
+    elif [ "$OPTION" == "" ]; then
+      echo "Service is $SERVICE_STATE"
+      OPTION=$(Choose "Enable" "Disable")
+    fi
+    if [[ "${OPTION,,}" =~ ^enable ]]; then
+      systemctl enable --user --now sunshine.service
+    elif [[ "${OPTION,,}" =~ ^(remove|uninstall|disable) ]]; then
+      systemctl disable --user --now sunshine.service 
+    fi

--- a/packages.json
+++ b/packages.json
@@ -73,6 +73,7 @@
 				"sssd-krb5",
 				"sssd-nfs-idmap",
 				"starship",
+				"sunshine",
 				"tailscale",
 				"tmux",
 				"ublue-bling",


### PR DESCRIPTION
Adds the sunshine copr, installs sunshine package and disables the global service.

also adds a ujust script to enable the user service for sunshine
