### PR TITLE
fix: Revert "feat: remove v4l2loopback and rpmfusion for Fedora 42+"

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -39,8 +39,15 @@ AKMODS=(
 )
 dnf5 -y install "${AKMODS[@]}"
 
-# Install v4l2loopback from terra or gracefully fail
-dnf5 -y install --repo="terra" /tmp/akmods/kmods/*v4l2loopback*.rpm || true
+# RPMFUSION Dependent AKMODS
+dnf5 -y install \
+        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
+        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
+
+dnf5 -y install \
+        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
+
+dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
 
 # Nvidia AKMODS
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -44,7 +44,7 @@ dnf5 -y install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
 
-dnf5 -y install \
+dnf5 -y install --repo="rpmfusion-free" \
         v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
 
 dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release


### PR DESCRIPTION
Also partial revert "feat: install v4l2loopback from terra (#2339)"

This reverts commit 3ff7e659d827648c0a7435f5ed7f711226e17929.

Also this removes the terra installed v4l2loopback in a partial revert of commit fa23c87eaef6677dfb44ac816a0c390923e908dc.

