### PR TITLE
chore: use docker packages from the stable repo

### DIFF
--- a/build_files/dx/04-override-install-dx.sh
+++ b/build_files/dx/04-override-install-dx.sh
@@ -16,10 +16,4 @@ tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu
 mv /tmp/ls-iommu/ls-iommu /usr/bin/
 rm -rf /tmp/ls-iommu*
 
-# Install Docker Release Candidate - remove this when F42 packages are pushed to the stable repos
-# https://download.docker.com/linux/fedora/42/x86_64/stable/Packages/
-if [[ $FEDORA_MAJOR_VERSION -eq 42 ]]; then
-    dnf install -y --enablerepo=docker-ce-testing docker-buildx-plugin docker-ce docker-ce-cli docker-compose-plugin
-fi
-
 echo "::endgroup::"

--- a/packages.json
+++ b/packages.json
@@ -105,6 +105,10 @@
 				"code",
 				"containerd.io",
 				"dbus-x11",
+				"docker-buildx-plugin",
+				"docker-ce",
+				"docker-ce-cli",
+				"docker-compose-plugin"
 				"edk2-ovmf",
 				"flatpak-builder",
 				"genisoimage",
@@ -174,12 +178,7 @@
 				"epson-inkjet-printer-escpr2",
 				"google-noto-fonts-all"
 			],
-			"dx":[
-				"docker-buildx-plugin",
-				"docker-ce",
-				"docker-ce-cli",
-				"docker-compose-plugin"
-			]
+			"dx":[]
 		},
 		"exclude": {
 			"all": [],

--- a/packages.json
+++ b/packages.json
@@ -188,8 +188,8 @@
 	"42": {
 		"include": {
 			"all": [
-        		"google-noto-fonts-all",
-        		"uupd",
+				"google-noto-fonts-all",
+				"uupd",
 				"fw-fanctrl"
       		],
 			"dx": []

--- a/packages.json
+++ b/packages.json
@@ -108,7 +108,7 @@
 				"docker-buildx-plugin",
 				"docker-ce",
 				"docker-ce-cli",
-				"docker-compose-plugin"
+				"docker-compose-plugin",
 				"edk2-ovmf",
 				"flatpak-builder",
 				"genisoimage",

--- a/packages.json
+++ b/packages.json
@@ -189,8 +189,8 @@
 	"42": {
 		"include": {
 			"all": [
-        			"google-noto-fonts-all",
-        			"uupd",
+        		"google-noto-fonts-all",
+        		"uupd",
 				"fw-fanctrl"
       		],
 			"dx": []

--- a/system_files/dx/etc/yum.repos.d/docker-ce.repo
+++ b/system_files/dx/etc/yum.repos.d/docker-ce.repo
@@ -4,10 +4,3 @@ baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/stable
 enabled=1
 gpgcheck=1
 gpgkey=https://download.docker.com/linux/fedora/gpg
-
-[docker-ce-testing]
-name=Docker CE Testing - $basearch
-baseurl=https://download.docker.com/linux/fedora/$releasever/$basearch/test
-enabled=0
-gpgcheck=1
-gpgkey=https://download.docker.com/linux/fedora/gpg


### PR DESCRIPTION
Replaces the "testing" packages with dockers stable repo packages
