### PR TITLE
feat: enable ganto copr for incus

### DIFF
--- a/build_files/dx/01-install-copr-repos-dx.sh
+++ b/build_files/dx/01-install-copr-repos-dx.sh
@@ -6,9 +6,7 @@ set -eoux pipefail
 
 #incus, lxc, lxd
 
-if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
-    dnf5 -y copr enable ganto/lxc4
-fi
+dnf5 -y copr enable ganto/lxc4
 
 #umoci
 dnf5 -y copr enable ganto/umoci


### PR DESCRIPTION
Enable ganto copr for incus etc for Fedora 42
