### PR TITLE
fix(hwe): switch to skip-unavailable

### DIFF
--- a/build_files/base/09-hwe-additions.sh
+++ b/build_files/base/09-hwe-additions.sh
@@ -32,7 +32,7 @@ SURFACE_PACKAGES=(
     pipewire-plugin-libcamera
 )
 
-dnf5 -y install \
+dnf5 -y install --skip-unavailable \
     "${ASUS_PACKAGES[@]}" \
     "${SURFACE_PACKAGES[@]}"
 


### PR DESCRIPTION
surface is still missing some packages, switch to skipping them until they are available but enable builds

https://github.com/ublue-os/bluefin/pull/2378