### PR TITLE
chore: remove skanpage rpm

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -68,7 +68,6 @@
 				"samba-winbind-modules",
 				"scx-scheds",
 				"setools-console",
-				"skanpage",
 				"sssd-ad",
 				"sssd-ipa",
 				"sssd-krb5",


### PR DESCRIPTION
This is now as a flatpak, i thought we had removed this already

