### PR TITLE
fix(nvidia-open): correctly identify nvidia-open on image-info.json

### DIFF
--- a/build_files/base/00-image-info.sh
+++ b/build_files/base/00-image-info.sh
@@ -20,6 +20,9 @@ image_flavor="main"
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
   image_flavor="nvidia"
 fi
+if [[ "${IMAGE_NAME}" =~ nvidia-open ]]; then
+  image_flavor="nvidia-open"
+fi
 
 cat >$IMAGE_INFO <<EOF
 {


### PR DESCRIPTION
from https://github.com/ublue-os/bluefin/pull/2355
