### PR TITLE
fix: devpod flatpak fix for nvidia

### DIFF
--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # SCRIPT VERSION
-USER_SETUP_VER=10
+USER_SETUP_VER=11
 USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
 USER_SETUP_VER_RAN=$(cat "$USER_SETUP_VER_FILE")
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
@@ -68,6 +68,9 @@ flatpak override --user --unset-env=QT_QPA_PLATFORMTHEME
 
 # smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
 flatpak override --user --env=USE_POINTER_VIEWPORT=1
+
+# webkit2gtk override to devpod for nvidia users
+flatpak override --user --env=WEBKIT_DISABLE_COMPOSITING_MODE=1 sh.loft.devpod
 
 # Handle privileged tasks
 pkexec /usr/libexec/ublue-privileged-user-setup

--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -69,7 +69,7 @@ flatpak override --user --unset-env=QT_QPA_PLATFORMTHEME
 # smaller cursor on GTK apps - should be fixed by F42 with GTK 4.17
 flatpak override --user --env=USE_POINTER_VIEWPORT=1
 
-# webkit2gtk override to devpod for nvidia users
+# webkit override to devpod for nvidia users
 flatpak override --user --env=WEBKIT_DISABLE_COMPOSITING_MODE=1 sh.loft.devpod
 
 # Handle privileged tasks


### PR DESCRIPTION
devpod flatpak has issue with nvidia, this sets env override for the flatpak devpod app