### PR TITLE
fix: show prompt for installing stress-ng via brew if not installed

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -14,10 +14,19 @@
 [group('System')]
 benchmark:
     #!/usr/bin/env bash
-    echo 'Running a 1 minute benchmark ...'
-    trap popd EXIT
-    pushd $(mktemp -d)
-    stress-ng --matrix 0 -t 1m --times
+    source /usr/lib/ujust/ujust.sh
+    if ! type -P "stress-ng" &>/dev/null ; then
+        if gum confirm "Stress does not seem to be on your path, do you wish to install it?" ; then
+            set -eu
+            brew install stress-ng
+            brew link stress-ng
+            set +eu
+        else
+            exit 0
+        fi
+    fi
+
+
 
 # Configure Aurora-CLI Terminal Experience with Brew
 [group('System')]


### PR DESCRIPTION
from https://github.com/ublue-os/bluefin/pull/2413

