### PR TITLE
feat: integrate firewall-config as a kcm

### DIFF
--- a/system_files/kinoite/usr/share/plasma/systemsettings/externalmodules/kcm_external_firewall-config.desktop
+++ b/system_files/kinoite/usr/share/plasma/systemsettings/externalmodules/kcm_external_firewall-config.desktop
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: CC0-1.0
+# SPDX-FileCopyrightText: 2025 Thomas Duckworth <tduck@filotimoproject.org>
+[Desktop Entry]
+Type=Service
+TryExec=firewall-config
+Exec=firewall-config
+Icon=preferences-security-firewall
+X-KDE-Weight=1
+X-KDE-ServiceTypes=SystemSettingsExternalApp
+X-KDE-System-Settings-Parent-Category=network
+X-KDE-ParentApp=systemsettings
+Name=Firewall
+Comment=Allows configuring the firewall
+X-KDE-Keywords=network,firewall,firewalld,networking,ufw,tcp,udp,port,service


### PR DESCRIPTION
Adds an external KCM that opens `firewall-config` in System Settings.

![image](https://github.com/user-attachments/assets/00e9b107-b6ab-4ac2-9c4d-8db7a570756a)
