### PR TITLE
fix: make samba usershares work OOTB

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -45,4 +45,13 @@ glib-compile-schemas /usr/share/glib-2.0/schemas &>/dev/null
 # Watermark for Plymouth
 cp /usr/share/plymouth/themes/spinner/{"$BASE_IMAGE_NAME"-,}watermark.png
 
+# Make Samba usershares work OOTB
+mkdir -p /var/lib/samba/usershares
+chown -R root:usershares /var/lib/samba/usershares
+firewall-offline-cmd --service=samba --service=samba-client
+setsebool -P samba_enable_home_dirs=1
+setsebool -P samba_export_all_ro=1
+setsebool -P samba_export_all_rw=1
+sed -i '/^\[homes\]/,/^\[/{/^\[homes\]/d;/^\[/!d}' /etc/samba/smb.conf
+
 echo "::endgroup::"


### PR DESCRIPTION
Sets up SELinux and firewalld so that creating a Samba usershare through Dolphin (right click a folder -> Properties -> Share) works without silently failing, as well as preventing Samba from automatically exporting users' home folder as a share.