### PR TITLE
fix: cleanup dockerenv in brew.sh

### DIFF
--- a/build_files/base/10-brew.sh
+++ b/build_files/base/10-brew.sh
@@ -17,4 +17,8 @@ chmod +x /tmp/brew-install
 /tmp/brew-install
 tar --zstd -cvf /usr/share/homebrew.tar.zst /home/linuxbrew/.linuxbrew
 
+# This blows up local/non-rechunked builds otherwise
+# as the booted system is recognized as a container
+rm /.dockerenv
+
 echo "::endgroup::"


### PR DESCRIPTION
This blows up local/non-rechunked on F42 builds as the system is recognized as a container otherwise
![image](https://github.com/user-attachments/assets/3493a239-1d58-483c-a8d4-2472a27a4ae5)

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
