### PR TITLE
chore: drop building asus and surface images

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -183,18 +183,6 @@ jobs:
               podman push ${{ env.IMAGE_NAME }}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
             done
 
-            if [[ "${{ matrix.image_flavor }}" =~ hwe ]]; then
-
-              image_name="${{ env.IMAGE_NAME }}"
-              asus_name="${image_name/hwe/asus}"
-              surface_name="${image_name/hwe/surface}"
-
-              for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
-                podman push ${asus_name}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${asus_name}:${tag}
-                podman push ${surface_name}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${surface_name}:${tag}
-              done
-            fi
-
             digest=$(skopeo inspect docker://${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }} --format '{{.Digest}}')
 
             echo "digest=${digest}" >> $GITHUB_OUTPUT
@@ -207,20 +195,6 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
-        env:
-          TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
-      - name: Sign container image
-        if: github.event_name != 'pull_request' && contains(matrix.image_flavor, 'hwe')
-        shell: bash
-        run: |
-          image_name="${{ env.IMAGE_NAME }}"
-          asus_name="${image_name/hwe/asus}"
-          surface_name="${image_name/hwe/surface}"
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${asus_name}@${TAGS}
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${surface_name}@${TAGS}
         env:
           TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
           COSIGN_EXPERIMENTAL: false


### PR DESCRIPTION
I think its time to say goodbye to our Asus and surface images as was planned when F42 hits.
