### PR TITLE
chore: add upstream bootc config for nvidia and bootc install

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -69,6 +69,9 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
   IMAGE_NAME="${BASE_IMAGE_NAME}" RPMFUSION_MIRROR="" /tmp/nvidia-install.sh
   rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
   ln -sf libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so
+  tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<EOF
+kargs = ["rd.driver.blacklist=nouveau", "modprobe.blacklist=nouveau", "nvidia-drm.modeset=1", "initcall_blacklist=simpledrm_platform_driver_init"]
+EOF
 fi
 
 # ZFS for stable

--- a/system_files/shared/usr/lib/bootc/install/20-aurora.toml
+++ b/system_files/shared/usr/lib/bootc/install/20-aurora.toml
@@ -1,0 +1,2 @@
+[install]
+root-fs-type = "btrfs"


### PR DESCRIPTION
This just adds a default filesystem type for aurora (btrfs) (makes it so bootc install to-disk works w/o modifications), and adds nvidia kargs on nvidia builds, shouldnt affect anything retroarctively

just so we are up-to-date once we are implementing readymade