### PR TITLE
chore: remove kcharselect

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -20,4 +20,3 @@ runtime/org.gtk.Gtk3theme.Breeze/x86_64/3.22
 app/io.github.pwr_solaar.solaar/x86_64/stable
 app/org.gustavoperedo.FontDownloader/x86_64/stable
 app/org.kde.skanpage/x86_64/stable
-app/org.kde.kcharselect/x86_64/stable

--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -20,3 +20,4 @@ runtime/org.gtk.Gtk3theme.Breeze/x86_64/3.22
 app/io.github.pwr_solaar.solaar/x86_64/stable
 app/org.gustavoperedo.FontDownloader/x86_64/stable
 app/org.kde.skanpage/x86_64/stable
+app/org.kde.kcharselect/x86_64/stable

--- a/packages.json
+++ b/packages.json
@@ -163,6 +163,7 @@
 			"all": [
 				"firefox",
 				"firefox-langpacks",
+				"kcharselect",
 				"krfb",
 				"krfb-libs",
 				"plasma-welcome-fedora",


### PR DESCRIPTION
Kcharselect has a flatpak
https://flathub.org/apps/org.kde.kcharselect

We don't need it in the image, it's just a tool to copy characters from all installed fonts.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
