### PR TITLE
chore(readme): Replace CONTRIBUTING link from Bluefin to Universal Blue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Aurora
 
->This README is under construction temporarily as we cleanup the repository after splitting away from [Bluefin](https://github.com/ublue-os/bluefin).
-
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/a940189170c8456c85a75ea36edb32c7)](https://app.codacy.com/gh/ublue-os/aurora/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 [![Stable Images](https://github.com/ublue-os/aurora/actions/workflows/build-image-stable.yml/badge.svg)](https://github.com/ublue-os/aurora/actions/workflows/build-image-stable.yml) [![Latest Images](https://github.com/ublue-os/aurora/actions/workflows/build-image-latest-main.yml/badge.svg)](https://github.com/ublue-os/aurora/actions/workflows/build-image-latest-main.yml) [![Latest Images HWE](https://github.com/ublue-os/aurora/actions/workflows/build-image-latest-hwe.yml/badge.svg)](https://github.com/ublue-os/aurora/actions/workflows/build-image-latest-hwe.yml) [![Beta Images](https://github.com/ublue-os/aurora/actions/workflows/build-image-beta.yml/badge.svg)](https://github.com/ublue-os/aurora/actions/workflows/build-image-beta.yml)
@@ -18,7 +16,7 @@ Aurora is a delightful KDE desktop experience for end-users that are looking for
 
 1. [Discussions and Announcements](https://universal-blue.discourse.group/c/aurora/11) - strongly recommended!
 2. [Documentation](https://docs.getaurora.dev/)
-3. [Contributing Guide](https://docs.projectbluefin.io/contributing)
+3. [Contributing Guide](https://universal-blue.org/contributing.html)
 
 ### Secure Boot
 


### PR DESCRIPTION
Also remove the note about the README being under construction.  The split has been over for a while.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
