### PR TITLE
chore: pin Stable to kernel 6.13.8

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,6 +23,7 @@ jobs:
       matrix:
         brand_name: ["aurora"]
     with:
+      kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
This is required because Fedora CoreOS stable moved to a rawhide kernel which isn't available in F41.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
