### PR TITLE
fix(uupd): disable distrobox module from uupd

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -4,6 +4,9 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
+# disable uupd from updating distroboxes
+sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
+
 # Setup Systemd
 systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -5,7 +5,9 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # disable uupd from updating distroboxes
+if [[ "$(rpm -E %fedora)" -eq "42" ]]; then
 sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
+fi
 
 # Setup Systemd
 systemctl enable rpm-ostree-countme.service

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -2,4 +2,4 @@ images:
   - name: kinoite-nvidia
     image: ghcr.io/ublue-os/kinoite-nvidia
     tag: latest
-    digest: sha256:b61333f1cb57e2c726f87db0930e70f818577247cbd07ea0ca4e401fefd53b46
+    digest: sha256:0b695f02d5727c22b9ceba5ac3032ef6be21cea44cb02d57dfa81e96bb8ed446


### PR DESCRIPTION
Disables updating distroboxes during uupd run.

Needs the newest uupd, so drafting until build is done
