### PR TITLE
chore: remove fedora-chromium-config* and fedora-bookmarks package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -162,6 +162,9 @@
 		},
 		"exclude": {
 			"all": [
+				"fedora-bookmarks",
+				"fedora-chromium-config",
+				"fedora-chromium-config-kde",
 				"firefox",
 				"firefox-langpacks",
 				"kcharselect",


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
