### PR TITLE
fix: restore fwupd backend to discover

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -28,7 +28,7 @@ sed -i 's@Exec=ptyxis@Exec=kde-ptyxis@g' /usr/share/applications/org.gnome.Ptyxi
 sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop
 cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
 
-# Remove KNewStuff and fwupd from Discover
+# Remove KNewStuff from Discover
 rm -f /usr/lib64/qt6/plugins/discover/kns-backend.so
 
 rm -f /etc/profile.d/gnome-ssh-askpass.{csh,sh} # This shouldn't be pulled in

--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -29,7 +29,7 @@ sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gno
 cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
 
 # Remove KNewStuff and fwupd from Discover
-rm -f /usr/lib64/qt6/plugins/discover/{fwupd,kns}-backend.so
+rm -f /usr/lib64/qt6/plugins/discover/kns-backend.so
 
 rm -f /etc/profile.d/gnome-ssh-askpass.{csh,sh} # This shouldn't be pulled in
 


### PR DESCRIPTION
Restores the firmware updater (fwupd) backend to Discover. 