### PR TITLE
chore: pin kernel to 6.14.5

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         brand_name: ["aurora"]
     with:
-      # kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.14.5-300.fc42.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Because of the Intel wifi issues with 6.14.3 it was suggested to pin to 6.14.5

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
