### PR TITLE
fix(iso): Use F41 for ISO

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -499,7 +499,11 @@ build-iso $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
     fi
 
     # Fedora Version
-    FEDORA_VERSION=$(${PODMAN} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["ostree.linux"]' | grep -oP 'fc\K[0-9]+')
+    # if [[ "$tag" != lts ]]; then
+    #     FEDORA_VERSION=$(${PODMAN} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["ostree.linux"]' | grep -oP 'fc\K[0-9]+')
+    # else
+    FEDORA_VERSION=41
+    # fi
 
     # Load Image into rootful podman
     if [[ "${UID}" -gt 0 && {{ ghcr }} == "0" && ! "${PODMAN}" =~ docker ]]; then


### PR DESCRIPTION
Move back to F41 installer because of the wayland issues users are seeing with the installer