### PR TITLE
feat(iso): Move to LiveCD with old anaconda installer

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -1,5 +1,5 @@
 ---
-name: Build ISOs (Live Anaconda)
+name: Build ISOs (Live Anaconda without Webui)
 
 on:
   workflow_dispatch:
@@ -65,7 +65,7 @@ jobs:
           image_ref="${IMAGE_REGISTRY}/${image_name}"
           KARGS="NONE"
           echo "image_ref=$image_ref" >> "${GITHUB_OUTPUT}"
-          echo "artifact_format="$image_name-${{ matrix.image_version }}-live"" >> "${GITHUB_OUTPUT}"
+          echo "artifact_format="$image_name-${{ matrix.image_version }}-$(uname -m)"" >> "${GITHUB_OUTPUT}"
           echo "kargs=$KARGS" >> "${GITHUB_OUTPUT}"
 
       - name: Build ISO

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/reusable-build-iso-anaconda.yml"
       - "iso_files/configure_iso_anaconda.sh"
   schedule:
-    - cron: "0 0 * * 0"
+    - cron: "0 0 * * 1"
 
 env:
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -1,5 +1,5 @@
 ---
-name: Build ISOs (Live Anaconda without Webui)
+name: Build ISOs (Live without Webui)
 
 on:
   workflow_dispatch:

--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -31,13 +31,12 @@ systemctl --global disable ublue-user-setup.service
 
 # Configure Anaconda
 
-# Install Anaconda, Webui if >= F42
+# Install Anaconda
 SPECS=(
     "libblockdev-btrfs"
     "libblockdev-lvm"
     "libblockdev-dm"
     "anaconda-live"
-    "anaconda-webui"
 )
 dnf install -y "${SPECS[@]}"
 


### PR DESCRIPTION
Creates a LiveCD environment but uses the old Anaconda installer without the webui (which doesn't work for KDE atm)

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
