### PR TITLE
fix: set SDDM wallpaper to the regular default wallpaper

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -18,6 +18,10 @@ ln -sf /usr/share/backgrounds/aurora/aurora-wallpaper-3/contents/images/3840x216
 ln -sf /usr/share/backgrounds/aurora/aurora-wallpaper-3/contents/images/3840x2160.png /usr/share/backgrounds/default-dark.png
 ln -sf /usr/share/backgrounds/aurora/aurora.xml /usr/share/backgrounds/default.xml
 
+# /usr/share/sddm/themes/01-breeze-fedora/theme.conf uses default.jxl for the background
+ln -sf /usr/share/backgrounds/default.png /usr/share/backgrounds/default.jxl
+ln -sf /usr/share/backgrounds/default-dark.png /usr/share/backgrounds/default-dark.jxl
+
 # Favorites in Kickoff
 sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:org.gnome.Ptyxis.desktop,applications:org.kde.discover.desktop,preferred:\/\/filemanager<\/default>/' /usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml
 sed -i '/<entry name="favorites" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,systemsettings.desktop,org.kde.dolphin.desktop,org.kde.kate.desktop,org.gnome.Ptyxis.desktop,org.kde.discover.desktop<\/default>/' /usr/share/plasma/plasmoids/org.kde.plasma.kickoff/contents/config/main.xml


### PR DESCRIPTION
Right now the default sddm background is the fedora wallpaper.

Fedora changed the backgrounds from png to jxl (now that they ship jxl wallpapers with F42) they also set `default.jxl` in `/usr/share/sddm/themes/01-breeze-fedora/theme.conf` so this sets the SDDM wallpaper to whatever is the regular wallpaper.


<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
