### PR TITLE
fix(ujust): unindent recipe name after refactor

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -247,7 +247,8 @@ configure-vfio ACTION="":
 
 # Install system flatpaks for rebasers
 [group('System')]
-  install-system-flatpaks $dx="dynamic":
+install-system-flatpaks $dx="dynamic":
+  #!/usr/bin/env bash
   TARGET_FLATPAK_FILE="${TARGET_FLATPAK_FILE:-/etc/ublue-os/system-flatpaks.list}"
   TARGET_DEVMODE_FILE="${TARGET_DEVMODE_FILE:-/etc/ublue-os/system-flatpaks-dx.list}"
   case "$dx" in


### PR DESCRIPTION
Reports from Discord that the main ujust is broken with https://github.com/ublue-os/aurora/pull/531. The simple fix is to remove the unintended indention.

```
ujust --choose
error: Unknown start of token '-'
   ——▶ just/60-custom.just:270:22
    │
270 │   flatpak remote-add --if-not-exists --system flathub https://flathub.org/repo/flathub.flatpakrepo
    │                      ^
```