### PR TITLE
chore: disable old rpm-ostreed-automatic.timer

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -30,6 +30,9 @@ systemctl --global disable sunshine.service
 # Updater
 systemctl enable uupd.timer
 
+# Disable the old update timer
+systemctl disable rpm-ostreed-automatic.timer
+
 # Hide Desktop Files. Hidden removes mime associations
 for file in fish htop nvtop; do
     if [[ -f "/usr/share/applications/$file.desktop" ]]; then

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -32,6 +32,7 @@ systemctl enable uupd.timer
 
 # Disable the old update timer
 systemctl disable rpm-ostreed-automatic.timer
+systemctl disable flatpak-system-update.timer
 
 # Hide Desktop Files. Hidden removes mime associations
 for file in fish htop nvtop; do


### PR DESCRIPTION
We have moved to uupd, so this can be disabled so it doesn't unneccessarily run the rpm-ostreed timer
