### PR TITLE
chore: remove devpod entry from changelogs

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -59,7 +59,6 @@ From previous `{target}` version `{prev}` there have been the following changes.
 | --- | --- |
 | **Incus** | {pkgrel:incus} |
 | **Docker** | {pkgrel:docker-ce} |
-| **Devpod** | {pkgrel:devpod} |
 
 {changes}
 


### PR DESCRIPTION
Devpod is now a flatpak, so it can be removed from the changelogs
