### PR TITLE
feat: change Boxbuddy to Distroshelf

### DIFF
--- a/iso_files/system-flatpaks.list
+++ b/iso_files/system-flatpaks.list
@@ -9,7 +9,7 @@ org.kde.kclock
 org.fkoehler.KTailctl
 org.kde.haruna
 com.github.tchx84.Flatseal
-io.github.dvlv.boxbuddyrs
+com.ranfdev.DistroShelf
 io.github.flattool.Warehouse
 org.fedoraproject.MediaWriter
 io.missioncenter.MissionCenter


### PR DESCRIPTION
Removes Boxbuddy and replaces it with Distroshelf.

Maybe in the future we can replace this with Kontainer once it matures

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
