### PR TITLE
feat: add new deployment notification to starship prompt

### DIFF
--- a/system_files/shared/etc/skel/.config/starship.toml
+++ b/system_files/shared/etc/skel/.config/starship.toml
@@ -197,3 +197,10 @@ symbol = " "
 [gradle]
 symbol = " "
 
+[custom.update]
+when = "/usr/bin/rpm-ostree status --json | /usr/bin/jq -e \".deployments[0].booted == false\" > /dev/null;"
+command = 'echo "New deployment staged"'
+symbol = ""
+format = " $symbol [($output)]($style) "
+style = "italic green"
+


### PR DESCRIPTION
Adds a little notification to starship prompt when there is new image deployment waiting for reboot

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
