### PR TITLE
chore: remove framework-kmod

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -33,7 +33,6 @@ dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel
 sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 AKMODS=(
     /tmp/akmods/kmods/*xone*.rpm
-    /tmp/akmods/kmods/*framework-laptop*.rpm
     /tmp/akmods/kmods/*openrazer*.rpm
 )
 dnf5 -y install "${AKMODS[@]}"

--- a/system_files/shared/etc/modprobe.d/cros_charge_control.conf
+++ b/system_files/shared/etc/modprobe.d/cros_charge_control.conf
@@ -1,0 +1,1 @@
+options cros_charge_control probe_with_fwk_charge_control=1


### PR DESCRIPTION
Seems this is not needed with kernel 6.14 anymore

ref:
https://community.frame.work/t/charge-levels-configurable-from-kde-userspace/69432/10

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
