### PR TITLE
fix: v4l2loopback

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -43,7 +43,7 @@ dnf5 -y install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
 
-dnf5 -y install --repo="rpmfusion-free" \
+dnf5 -y install \
         v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
 
 dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release


### PR DESCRIPTION
For some reason (propably legacy debt) this was trying to pull it from two different places, which broke our builds.