### PR TITLE
feat: change Pika Backup to Vorta

### DIFF
--- a/iso_files/system-flatpaks.list
+++ b/iso_files/system-flatpaks.list
@@ -14,7 +14,7 @@ io.github.flattool.Warehouse
 org.fedoraproject.MediaWriter
 io.missioncenter.MissionCenter
 org.gnome.DejaDup
-org.gnome.World.PikaBackup
+com.borgbase.Vorta
 io.github.input_leap.input-leap
 org.gtk.Gtk3theme.Breeze
 io.github.pwr_solaar.solaar


### PR DESCRIPTION
Pika doesn't work with password protected archives OOTB on KDE
