### PR TITLE
fix: actually replace boxbuddy with distroshelf

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -14,7 +14,7 @@ app/io.github.flattool.Warehouse
 app/org.fedoraproject.MediaWriter
 app/io.missioncenter.MissionCenter
 app/org.gnome.DejaDup
-app/org.gnome.World.PikaBackup
+app/com.borgbase.Vorta
 app/io.github.input_leap.input-leap
 runtime/org.gtk.Gtk3theme.Breeze
 app/io.github.pwr_solaar.solaar

--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -9,7 +9,7 @@ app/org.kde.kclock
 app/org.fkoehler.KTailctl
 app/org.kde.haruna
 app/com.github.tchx84.Flatseal
-app/io.github.dvlv.boxbuddyrs
+app/com.ranfdev.DistroShelf
 app/io.github.flattool.Warehouse
 app/org.fedoraproject.MediaWriter
 app/io.missioncenter.MissionCenter


### PR DESCRIPTION
we forgot to change it here as well
https://github.com/ublue-os/aurora/pull/570
https://github.com/ublue-os/aurora/pull/552