### PR TITLE
chore: remove libheif workaround

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -21,17 +21,6 @@ set -eoux pipefail
 curl --retry 3 -Lo /tmp/aurora.pdf https://github.com/ublue-os/aurora-docs/releases/download/0.1/aurora.pdf
 install -Dm0644 -t /usr/share/doc/aurora/ /tmp/aurora.pdf
 
-# TODO: Fedora 42 specific -- re-evaluate with Fedora 43
-# negativo's libheif is broken somehow on older Intel machines
-# https://github.com/ublue-os/aurora/issues/8
-dnf5 -y swap \
-    --repo=fedora \
-        libheif libheif
-        
-dnf5 -y swap \
-    --repo=fedora \
-        heif-pixbuf-loader heif-pixbuf-loader
-
 # Starship Shell Prompt
 # shellcheck disable=SC2016
 echo 'eval "$(starship init bash)"' >> /etc/bashrc


### PR DESCRIPTION
Someone on discord with previously affected hardware showed a working bazzite kde the other day which never shipped this workaround.

We don't need this anymore, this must have gotten resolved upstream with 1.19.8 https://github.com/strukturag/libheif/releases/tag/v1.19.8

I tried an image with this change on my laptop that was previously affected and this totally works now!

https://github.com/ublue-os/aurora/issues/8

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
