### PR TITLE
chore: remove hidden desktop entry section for gnome-system-monitor

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -4,14 +4,6 @@ echo "::group:: ===$(basename "$0")==="
 
 set -ouex pipefail
 
-# Remove desktop entries
-if [[ -f /usr/share/applications/gnome-system-monitor.desktop ]]; then
-    sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/gnome-system-monitor.desktop
-fi
-if [[ -f /usr/share/applications/org.gnome.SystemMonitor.desktop ]]; then
-    sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/org.gnome.SystemMonitor.desktop
-fi
-
 # Branding for Images
 ln -sf ../places/distributor-logo.svg /usr/share/icons/hicolor/scalable/apps/start-here.svg
 ln -sf /usr/share/backgrounds/aurora/aurora-wallpaper-3/contents/images/3840x2160.png /usr/share/backgrounds/default.png


### PR DESCRIPTION
we do not ship gnome-system-monitor

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
