### PR TITLE
fix: prevent plasma-firewall package skew

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -18,6 +18,10 @@ dnf5 -y swap \
   --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
   fwupd fwupd
 
+# Explicitly install KDE Plasma related packages with the same version as in base image
+dnf5 -y install \
+  plasma-firewall-$(rpm -q --qf "%{VERSION}" plasma-desktop)
+
 # Offline Aurora documentation
 curl --retry 3 -Lo /tmp/aurora.pdf https://github.com/ublue-os/aurora-docs/releases/download/0.1/aurora.pdf
 install -Dm0644 -t /usr/share/doc/aurora/ /tmp/aurora.pdf

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -5,18 +5,18 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # Patched shell and switcheroo-control
-  dnf5 -y swap \
-      --repo="terra-extras" \
-          kf6-kio kf6-kio-$(rpm -q --qf "%{VERSION}" kf6-kcoreaddons)
+dnf5 -y swap \
+  --repo="terra-extras" \
+  kf6-kio kf6-kio-$(rpm -q --qf "%{VERSION}" kf6-kcoreaddons)
 
-  dnf5 -y swap \
-      --repo="terra-extras" \
-          switcheroo-control switcheroo-control
+dnf5 -y swap \
+  --repo="terra-extras" \
+  switcheroo-control switcheroo-control
 
 # Fix for ID in fwupd
-  dnf5 -y swap \
-      --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
-          fwupd fwupd
+dnf5 -y swap \
+  --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+  fwupd fwupd
 
 # Offline Aurora documentation
 curl --retry 3 -Lo /tmp/aurora.pdf https://github.com/ublue-os/aurora-docs/releases/download/0.1/aurora.pdf

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -7,7 +7,8 @@ set -eoux pipefail
 # Patched shell and switcheroo-control
   dnf5 -y swap \
       --repo="terra-extras" \
-          kf6-kio kf6-kio-$(rpm -qi kf6-kcoreaddons | awk '/^Version/ {print $3}')
+          kf6-kio kf6-kio-$(rpm -q --qf "%{VERSION}" kf6-kcoreaddons)
+
   dnf5 -y swap \
       --repo="terra-extras" \
           switcheroo-control switcheroo-control

--- a/packages.json
+++ b/packages.json
@@ -126,7 +126,6 @@
 				"osbuild-selinux",
 				"p7zip",
 				"p7zip-plugins",
-				"plasma-firewall",
 				"podman-bootc",
 				"podman-compose",
 				"podman-machine",


### PR DESCRIPTION
when a new KDE version hits the repos and it's not in the base image yet then the plasma-firewall version will be newer than what's on the image.

removes the indent and doesn't call awk anymore for explicitly installing kf6-kio from terra