### PR TITLE
fix: remove leftover ungated fedora kernel on stable images

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -24,7 +24,7 @@ dnf5 -y install \
   /tmp/kernel-rpms/kernel-uki-virt-*.rpm
 
 
-dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra
+dnf5 versionlock add kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
 
 # Everyone
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -20,7 +20,9 @@ mv /tmp/rpms/* /tmp/akmods/
 dnf5 -y install \
   /tmp/kernel-rpms/kernel-[0-9]*.rpm \
   /tmp/kernel-rpms/kernel-core-*.rpm \
-  /tmp/kernel-rpms/kernel-modules-*.rpm
+  /tmp/kernel-rpms/kernel-modules-*.rpm \
+  /tmp/kernel-rpms/kernel-uki-virt-*.rpm
+
 
 dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra
 

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -24,7 +24,7 @@ dnf5 -y install \
   /tmp/kernel-rpms/kernel-uki-virt-*.rpm
 
 
-dnf5 versionlock add kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
+dnf5 versionlock add kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra kernel-uki-virt
 
 # Everyone
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -5,8 +5,8 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # Remove Existing Kernel
-for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra; do
-  rpm --erase $pkg --nodeps
+for pkg in kernel-{core,modules,modules-core,modules-extra,tools,tools-libs}; do
+  dnf5 -y remove $pkg --noautoremove
 done
 
 # Fetch Common AKMODS & Kernel RPMS
@@ -21,10 +21,6 @@ dnf5 -y install \
   /tmp/kernel-rpms/kernel-[0-9]*.rpm \
   /tmp/kernel-rpms/kernel-core-*.rpm \
   /tmp/kernel-rpms/kernel-modules-*.rpm
-
-# TODO: Figure out why akmods cache is pulling in akmods/kernel-devel
-dnf5 -y install \
-  /tmp/kernel-rpms/kernel-devel-*.rpm
 
 dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-modules kernel-modules-core kernel-modules-extra
 

--- a/packages.json
+++ b/packages.json
@@ -78,6 +78,7 @@
 				"uld",
 				"usbmuxd",
 				"uupd",
+				"virtualbox-guest-additions",
 				"wireguard-tools",
 				"wl-clipboard",
 				"xprop",

--- a/packages.json
+++ b/packages.json
@@ -19,7 +19,6 @@
 				"foo2zjs",
 				"freeipa-client",
 				"fuse-encfs",
-				"gcc",
 				"git-credential-libsecret",
 				"glow",
 				"gum",


### PR DESCRIPTION
right now there are leftovers in /usr/lib/modules/

removes a bunch of stuff that happens to be pulled in because of the kernel like build deps

all my commits have further explanations on why I did things this way/what the issue was

this shows exactly which packages will be removed from the image with this PR
[diff.txt](https://github.com/user-attachments/files/20854236/diff.txt)
 