### PR TITLE
chore: revert qt6-qtwayland pin

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -13,10 +13,6 @@ set -eoux pipefail
 # see https://bugzilla.redhat.com/show_bug.cgi?id=2365882
 dnf -y swap atheros-firmware atheros-firmware-20250311-1$(rpm -E %{dist})
 
-# Workaround for kscreenlocker regression
-# see https://bugzilla.redhat.com/show_bug.cgi?id=2375356
-dnf -y downgrade qt6-qtwayland-6.9.1-1$(rpm -E %{dist})
-
 
 # Current aurora systems have the bling.sh and bling.fish in their default locations
 mkdir -p /usr/share/ublue-os/aurora-cli


### PR DESCRIPTION
6.9.1-3 reverted the fedora patch that caused the initial breakage

https://bugzilla.redhat.com/show_bug.cgi?id=2375356
https://bugs.kde.org/show_bug.cgi?id=506316
https://github.com/ublue-os/aurora/commit/92b62319a809f4247bcad6cac047109d99214cc5

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
