### PR TITLE
fix: only enable Bazaar KRunner plugin on beta 

### DIFF
--- a/build_files/base/10-beta.sh
+++ b/build_files/base/10-beta.sh
@@ -9,6 +9,12 @@ fi
 
 sudo dnf5 install -y bazaar krunner-bazaar
 
+# For new users, enable Bazaar in KRunner + disable Discover results
+cat >> /usr/share/kde-settings/kde-profile/default/xdg/krunnerrc << 'EOF'
+krunner_appstreamEnabled=false
+bazaarrunnerEnabled=true
+EOF
+
 if jq -e '.["image-flavor"] | test("nvidia")' /usr/share/ublue-os/image-info.json >/dev/null; then
   sed -i 's|^Exec=bazaar window --auto-service$|Exec=env GSK_RENDERER=opengl bazaar window --auto-service|' /usr/share/applications/io.github.kolunmi.Bazaar.desktop
 fi

--- a/build_files/base/10-beta.sh
+++ b/build_files/base/10-beta.sh
@@ -11,6 +11,7 @@ sudo dnf5 install -y bazaar krunner-bazaar
 
 # For new users, enable Bazaar in KRunner + disable Discover results
 cat >> /usr/share/kde-settings/kde-profile/default/xdg/krunnerrc << 'EOF'
+[Plugins]
 krunner_appstreamEnabled=false
 bazaarrunnerEnabled=true
 EOF

--- a/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/krunnerrc
+++ b/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/krunnerrc
@@ -1,4 +1,2 @@
 [General]
 FreeFloating=true
-
-[Plugins]

--- a/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/krunnerrc
+++ b/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/krunnerrc
@@ -2,5 +2,3 @@
 FreeFloating=true
 
 [Plugins]
-krunner_appstreamEnabled=false
-bazaarrunnerEnabled=true


### PR DESCRIPTION
With https://github.com/ublue-os/aurora/pull/677, `latest` and `stable-daily` image now accidentally have a configuration that will disable Discover search results for newly created users. This isn't a big deal because we create ISO from `stable`, but we should fix it before it reaches `stable`.