### PR TITLE
chore: removed patched kf6-kio from terra

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -4,11 +4,6 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
-# Patched shell and switcheroo-control
-dnf5 -y swap \
-  --repo="terra-extras" \
-  kf6-kio kf6-kio-$(rpm -q --qf "%{VERSION}" kf6-kcoreaddons)
-
 dnf5 -y swap \
   --repo="terra-extras" \
   switcheroo-control switcheroo-control


### PR DESCRIPTION
this patch is upstream now and included in frameworks 6.16
https://invent.kde.org/frameworks/kio/-/merge_requests/1556
https://invent.kde.org/frameworks/kio/-/commits/v6.16.0?ref_type=tags

switcheroo-control has to stay for now as upstream hasn't made a release in 3 years, but this finally got merged
[gitlab.freedesktop.org/hadess/switcheroo-control/-/merge_requests/69](https://gitlab.freedesktop.org/hadess/switcheroo-control/-/merge_requests/69)