### PR TITLE
chore: remove ls-iommu script

### DIFF
--- a/build_files/dx/04-override-install-dx.sh
+++ b/build_files/dx/04-override-install-dx.sh
@@ -8,12 +8,4 @@ curl --retry 3 -Lo /tmp/kind "https://github.com/kubernetes-sigs/kind/releases/l
 chmod +x /tmp/kind
 mv /tmp/kind /usr/bin/kind
 
-# ls-iommu helper tool for listing devices in iommu groups (PCI Passthrough)
-DOWNLOAD_URL=$(curl --retry 3 https://api.github.com/repos/HikariKnight/ls-iommu/releases/latest | jq -r '.assets[] | select(.name| test(".*x86_64.tar.gz$")).browser_download_url')
-curl --retry 3 -Lo /tmp/ls-iommu.tar.gz "$DOWNLOAD_URL"
-mkdir /tmp/ls-iommu
-tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu.tar.gz -C /tmp/ls-iommu
-mv /tmp/ls-iommu/ls-iommu /usr/bin/
-rm -rf /tmp/ls-iommu*
-
 echo "::endgroup::"


### PR DESCRIPTION
This is continuously breaking our builds as GH Api gets hammered (propably by our workflows) and then ratelimits our access.

This should probably be made as a copr package...

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
