### PR TITLE
feat(ci): consistently use rootful container storage

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2
-          loopback-free: 0.5
 
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Maximize build space
-        uses: ublue-os/container-storage-action@8e3f8f5368cfce1595269830378c3d7ad0b1673b
+        uses: ublue-os/container-storage-action@1765c85a3c86829bfe216fbae1774fbc55d89b41
         with:
           target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,9 +43,11 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+        uses: ublue-os/container-storage-action@8e3f8f5368cfce1595269830378c3d7ad0b1673b
         with:
-          remove-codeql: true
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: 0.5
 
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -42,9 +42,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
-      - name: wait for /mnt to mount?
-        run: sleep 5
-
       - name: Maximize build space
         uses: ublue-os/container-storage-action@8e3f8f5368cfce1595269830378c3d7ad0b1673b
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
+      - name: wait for /mnt to mount?
+        run: sleep 5
+
       - name: Maximize build space
         uses: ublue-os/container-storage-action@8e3f8f5368cfce1595269830378c3d7ad0b1673b
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Maximize build space
-        uses: ublue-os/container-storage-action@8e3f8f5368cfce1595269830378c3d7ad0b1673b
+        uses: renner0e/container-storage-action@ffd1480175cebff315e38dea45e2e3de5a5c354c
         with:
           target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Maximize build space
-        uses: renner0e/container-storage-action@ffd1480175cebff315e38dea45e2e3de5a5c354c
+        uses: ublue-os/container-storage-action@8e3f8f5368cfce1595269830378c3d7ad0b1673b
         with:
           target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2

--- a/Justfile
+++ b/Justfile
@@ -202,6 +202,7 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     fi
 
     # Pull in most recent upstream base image
+    # if building locally/not ghcr pull the new image
     if [[ {{ ghcr }} == "0" ]]; then
         ${PODMAN} pull "ghcr.io/ublue-os/kinoite-main:${fedora_version}"
     fi
@@ -240,13 +241,13 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     ${PODMAN} build "${PODMAN_BUILD_ARGS[@]}" .
     echo "::endgroup::"
 
-    # Rechunk
+    # Rechunk the image if we are running inside ghcr or set the variable locally
     if [[ "{{ rechunk }}" == "1" && "{{ ghcr }}" == "1" && "{{ pipeline }}" == "1" ]]; then
-        {{ just }} rechunk "${image}" "${tag}" "${flavor}" 1 1
+        ${SUDOIF} {{ just }} rechunk "${image}" "${tag}" "${flavor}" 1 1
     elif [[ "{{ rechunk }}" == "1" && "{{ ghcr }}" == "1" ]]; then
-        {{ just }} rechunk "${image}" "${tag}" "${flavor}" 1
+        ${SUDOIF} {{ just }} rechunk "${image}" "${tag}" "${flavor}" 1
     elif [[ "{{ rechunk }}" == "1" ]]; then
-        {{ just }} rechunk "${image}" "${tag}" "${flavor}"
+        ${SUDOIF} {{ just }} rechunk "${image}" "${tag}" "${flavor}"
     fi
 
 # Build Image and Rechunk


### PR DESCRIPTION
this makes rechunk use rootfull container storage on Github runners, enabling the use of the [btrfs container storage action](https://github.com/ublue-os/container-storage-action) that utilizes the free space of `/mnt` inside the gh runner

It should not fail anymore because we were mixing rootfull and rootless container storages