### PR TITLE
fix(ci): load rechunked image into rootfull storage

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
         run: |
           set -eoux pipefail
-          just tag-images "${{ env.IMAGE_NAME }}" \
+          sudo -E $(command -v just) tag-images "${{ env.IMAGE_NAME }}" \
                           "${{ env.DEFAULT_TAG }}" \
                           "${{ steps.generate-tags.outputs.alias_tags }}"
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -120,7 +120,7 @@ jobs:
         id: load-rechunk
         shell: bash
         run: |
-          just load-rechunk "${{ matrix.base_name }}" \
+          sudo -E $(command -v just) load-rechunk "${{ matrix.base_name }}" \
                             "${{ env.DEFAULT_TAG }}" \
                             "${{ matrix.image_flavor }}"
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -184,7 +184,7 @@ jobs:
             set -euox pipefail
 
             for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
-              podman push ${{ env.IMAGE_NAME }}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
+              sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
             done
 
             if [[ "${{ matrix.image_flavor }}" =~ hwe ]]; then
@@ -194,8 +194,8 @@ jobs:
               surface_name="${image_name/hwe/surface}"
 
               for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
-                podman push ${asus_name}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${asus_name}:${tag}
-                podman push ${surface_name}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${surface_name}:${tag}
+                sudo -E podman push ${asus_name}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${asus_name}:${tag}
+                sudo -E podman push ${surface_name}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${surface_name}:${tag}
               done
             fi
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -128,7 +128,7 @@ jobs:
         id: secureboot
         shell: bash
         run: |
-          just secureboot "${{ matrix.base_name }}" \
+          sudo -E $(command -v just) secureboot "${{ matrix.base_name }}" \
                           "${{ env.DEFAULT_TAG }}" \
                           "${{ matrix.image_flavor }}"
 


### PR DESCRIPTION
This prefixes everything with sudo so the rooful container storage is used, the action previously loaded the rootfull image into the user container storage sometimes leading to running out of space on the biggest nvidia-dx image

https://github.com/ublue-os/aurora/actions/runs/16603485215/job/46969177272