### PR TITLE
chore: remove neovide from blocklist

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
+++ b/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
@@ -17,7 +17,6 @@ com.jetbrains.RustRover
 com.google.AndroidStudio
 io.neovim.nvim
 org.vim.Vim
-dev.neovide.neovide
 io.github.zyedidia.micro
 com.helix_editor.Helix
 org.gnu.emacs


### PR DESCRIPTION
neovide is not a CLI app
emacs and vim probably depend on issue 786
