### PR TITLE
feat: add sddm setting

### DIFF
--- a/system_files/shared/usr/lib/sddm/sddm.conf.d/kde_settings.conf
+++ b/system_files/shared/usr/lib/sddm/sddm.conf.d/kde_settings.conf
@@ -1,0 +1,5 @@
+[Theme]
+Current=01-breeze-aurora
+# The name comes from /usr/share/icons/breeze_cursors
+CursorTheme=breeze_cursors
+CursorSize=24


### PR DESCRIPTION
This sets the new sddm theme from:
https://github.com/ublue-os/packages/pull/816

This file actually sets the theme as the default, this won't change any existing setups as /etc wins over /usr. It just changes fedora to aurora anyway at the moment. No visual changes.

It can't be in packages repo as it conflicts with kde-settings-sddm package and I don't feel like ripping the fedora package apart right now.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
