### PR TITLE
chore: remove ramalama from image

### DIFF
--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -202,8 +202,15 @@ install-incus:
 [group('Apps')]
 install-k8s-dev-tools:
     #!/usr/bin/bash
-    echo "Adding Kubernetes command line tools..."
+    echo "☸️🛠️ Adding Kubernetes command line tools..."
     brew bundle --file /usr/share/ublue-os/homebrew/kubernetes.Brewfile
+
+# Install AI tools
+[group('Apps')]
+install-ai-tools:
+    #!/usr/bin/bash
+    echo "🧠🤖 Adding AI tools..."
+    brew bundle --file /usr/share/ublue-os/homebrew/bluefin-ai.Brewfile
 
 # Install gaming flatpaks
 # 23.08 runtime versions are needed for Heroic/Lutris

--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -210,7 +210,7 @@ install-k8s-dev-tools:
 install-ai-tools:
     #!/usr/bin/bash
     echo "🧠🤖 Adding AI tools..."
-    brew bundle --file /usr/share/ublue-os/homebrew/bluefin-ai.Brewfile
+    brew bundle --file /usr/share/ublue-os/homebrew/aurora-ai.Brewfile
 
 # Install gaming flatpaks
 # 23.08 runtime versions are needed for Heroic/Lutris

--- a/packages.json
+++ b/packages.json
@@ -137,7 +137,6 @@
 				"podman-tui",
 				"podmansh",
 				"powerline-fonts",
-				"python3-ramalama",
 				"qemu",
 				"qemu-char-spice",
 				"qemu-device-display-virtio-gpu",


### PR DESCRIPTION
fedoras package of ramalama is old and updates slowly. Moving this to brew

Also adds ujust recipe to install ai tools

Required: https://github.com/ublue-os/packages/pull/827