### PR TITLE
fix(rollback-helper): include nvidia and other image variants

### DIFF
--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -34,12 +34,14 @@ function rebase_helper() {
 
   # Step 1: Choose image variant
   echo "Select your Aurora image:"
-  IMAGE_OPTIONS=(aurora aurora-dx cancel)
-  selected_image=$(Choose "${IMAGE_OPTIONS[@]}")
-  [[ "$selected_image" == "cancel" ]] && exit 0
-
-  IMAGE_NAME="$selected_image"
-  base_image="${IMAGE_REGISTRY}/${IMAGE_NAME}"
+  IMAGE_OPTIONS=(aurora aurora-dx)
+  
+  # Add current image if it's not already in the list
+  if [[ ! " ${IMAGE_OPTIONS[*]} " =~ \ ${IMAGE_NAME}\  ]]; then
+    IMAGE_OPTIONS+=("${IMAGE_NAME}")
+  fi
+  
+  IMAGE_OPTIONS+=(cancel)
 
   # Step 2: Channel Selection
   declare -a CHANNELS


### PR DESCRIPTION
rollback-helper doesn't show nvidia or other variants currently.

picked fomr https://github.com/ublue-os/bluefin/pull/3025/
