### PR TITLE
feat(bazaar): add Sober

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -147,6 +147,7 @@ sections:
       - com.heroicgameslauncher.hgl
       - com.discordapp.Discord
       - net.lutris.Lutris
+      - org.vinegarhq.Sober
       - com.dec05eba.gpu_screen_recorder
       - com.github.Matoking.protontricks
       - com.obsproject.Studio


### PR DESCRIPTION
Sober is the 4th most popular app on Flathub. Makes sense to include in the gaming section.