### PR TITLE
fix(nvidia): Force NGL for GTK apps for now

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -13,12 +13,17 @@ set -eoux pipefail
 # see https://bugzilla.redhat.com/show_bug.cgi?id=2365882
 dnf -y swap atheros-firmware atheros-firmware-20250311-1$(rpm -E %{dist})
 
-
 # Current aurora systems have the bling.sh and bling.fish in their default locations
 mkdir -p /usr/share/ublue-os/aurora-cli
 cp /usr/share/ublue-os/bling/* /usr/share/ublue-os/aurora-cli
 
 # Try removing just docs (is it actually promblematic?)
 rm -rf /usr/share/doc/just/README.*.md
+
+# NVIDIA GTK4 bug
+# https://github.com/ublue-os/aurora/issues/841
+if jq -e '.["image-flavor"] | test("nvidia")' /usr/share/ublue-os/image-info.json >/dev/null; then
+  echo "GSK_RENDERER=ngl" >/usr/lib/environment.d/gsk.conf
+fi
 
 echo "::endgroup::"


### PR DESCRIPTION
There is some weird interaction with the latest NVIDIA drivers and apps using the Gtk4 toolkit. Pulling in https://github.com/ublue-os/bazzite/commit/bb0e8f0d9cfe26efa56eed0fa75b7d1e8c110c46 which might fix it.