### PR TITLE
chore: remove bazaar libdex workaround

### DIFF
--- a/build_files/base/11-bazaar.sh
+++ b/build_files/base/11-bazaar.sh
@@ -6,8 +6,6 @@ set -eoux pipefail
 
 ### Bazaar
 echo "Installing Bazaar workarounds"
-# Downgrade libdex to 0.9.1 because 0.10 makes bazaar crash under VMs and PCs with low specs
-dnf5 install -y libdex-0.9.1
 
 # Workaround for Bazaar on Nvidia systems
 if jq -e '.["image-flavor"] | test("nvidia")' /usr/share/ublue-os/image-info.json >/dev/null; then


### PR DESCRIPTION
bazzite removed it with
https://github.com/ublue-os/bazzite/commit/8785c414f066b4b726de9f5199fbf79de75ed016

tested on my VM that was previously busted