### PR TITLE
chore: remove unnecessary plymouth kcm disablement

### DIFF
--- a/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/kdeglobals
+++ b/system_files/shared/usr/share/kde-settings/kde-profile/default/xdg/kdeglobals
@@ -4,9 +4,6 @@ SingleClick=false
 ColorScheme=BreezeDark
 widgetStyle=Breeze
 
-[KDE Control Module Restrictions][$i]
-kcm_plymouth.desktop=false
-
 [General]
 TerminalApplication=kde-ptyxis
 TerminalService=org.gnome.Ptyxis.desktop


### PR DESCRIPTION
we do not ship kcm-plymouth, we don't need to disable it

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
