### PR TITLE
feat(bazaar): remove Damask, add Cameractrls

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -61,7 +61,6 @@ sections:
       - re.sonny.Eloquent
       - be.alexandervanhee.gradia
       - app.fotema.Fotema
-      - app.drey.Damask
       - io.github.pleromix.IceBox
       - io.github.nozwock.Packet
       - com.github.ADBeveridge.Raider
@@ -175,6 +174,7 @@ sections:
       - org.fedoraproject.MediaWriter
       - org.raspberrypi.rpi-imager
       - org.mozilla.vpn
+      - hu.irl.cameractrls
   - title: "Developers"
     subtitle: "Developers, developers, developers!"
     rows: 2


### PR DESCRIPTION
- Damask doesn't work in KDE.
- Cameractrls requested in https://github.com/ublue-os/aurora/issues/854#issuecomment-3205021402