### PR TITLE
chore: remove the bazaar specific nvidia fix

### DIFF
--- a/build_files/base/11-bazaar.sh
+++ b/build_files/base/11-bazaar.sh
@@ -7,11 +7,6 @@ set -eoux pipefail
 ### Bazaar
 echo "Installing Bazaar workarounds"
 
-# Workaround for Bazaar on Nvidia systems
-if jq -e '.["image-flavor"] | test("nvidia")' /usr/share/ublue-os/image-info.json >/dev/null; then
-  sed -i 's|^Exec=bazaar window --auto-service$|Exec=env GSK_RENDERER=opengl bazaar window --auto-service|' /usr/share/applications/io.github.kolunmi.Bazaar.desktop
-fi
-
 # Hide Discover entries by renaming them (allows for easy re-enabling)
 discover_apps=(
   "org.kde.discover.desktop"


### PR DESCRIPTION
We have the sledgehammer fix  in workarounds.sh file for all gtk4 apps [here](https://github.com/ublue-os/aurora/blob/7158f2108bbcb03224a5632ae17e7c7f61a1aae8/build_files/base/18-workarounds.sh#L25)