### PR TITLE
style: remove manual linebreak

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -76,8 +76,7 @@ sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:{cu
 ```
 
 ### Documentation
-Be sure to read the [documentation](https://docs.getaurora.dev/) for more information
-on how to use your cloud native system.
+Be sure to read the [documentation](https://docs.getaurora.dev/) for more information on how to use your cloud native system.
 """
 HANDWRITTEN_PLACEHOLDER = """\
 This is an automatically generated changelog for release `{curr}`."""


### PR DESCRIPTION
When running `ujust changelog` in a maximized terminal it renders like this:
<img width="855" height="127" alt="image" src="https://github.com/user-attachments/assets/d4957916-c43e-4ec5-8bf4-23d948b14f4e" />
There's the automatic rendering line break after "more", but then also the manual line break after "information".

This PR removes the manual line break, so that the rendering can take care of line breaks.