### PR TITLE
fix: use desktop-file-edit instead of sed

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -10,6 +10,7 @@ ln -sf /usr/share/backgrounds/aurora/aurora-wallpaper-4/contents/images/3840x216
 ln -sf /usr/share/backgrounds/aurora/aurora.xml /usr/share/backgrounds/default.xml
 
 # /usr/share/sddm/themes/01-breeze-fedora/theme.conf uses default.jxl for the background
+# We are lying about the extension
 ln -sf /usr/share/backgrounds/default.png /usr/share/backgrounds/default.jxl
 ln -sf /usr/share/backgrounds/default-dark.png /usr/share/backgrounds/default-dark.jxl
 

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -35,9 +35,9 @@ systemctl disable rpm-ostreed-automatic.timer
 systemctl disable flatpak-system-update.timer
 
 # Hide Desktop Files. Hidden removes mime associations
-for file in fish htop nvtop; do
-    if [[ -f "/usr/share/applications/$file.desktop" ]]; then
-        sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/"$file".desktop
+for file in htop nvtop; do
+    if [[ -f "/usr/share/applications/${file}.desktop" ]]; then
+        desktop-file-edit --set-key=Hidden --set-value=true /usr/share/applications/${file}.desktop
     fi
 done
 

--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -87,7 +87,7 @@ EOF
 echo "Aurora release $VERSION_ID ($VERSION_CODENAME)" >/etc/system-release
 
 sed -i 's/ANACONDA_PRODUCTVERSION=.*/ANACONDA_PRODUCTVERSION=""/' /usr/{,s}bin/liveinst || true
-sed -i 's|^Icon=.*|Icon=/usr/share/anaconda/pixmaps/fedora-logo-icon.png|' /usr/share/applications/liveinst.desktop || true
+desktop-file-edit --set-key=Icon --set-value=/usr/share/anaconda/pixmaps/fedora-logo-icon.png /usr/share/applications/liveinst.desktop
 
 # Get Artwork
 git clone --depth=1 https://github.com/ublue-os/packages.git /root/packages


### PR DESCRIPTION
- it's a little bit cleaner and safer
- fish doesn't have a desktop file anymore

We can't do it for ptyxis as desktop-file-edit doesn't support categories

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
