### PR TITLE
chore(bazaar): remove org.gnome.Builder

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -189,7 +189,6 @@ sections:
       - io.podman_desktop.PodmanDesktop
       - io.kinvolk.Headlamp
       - sh.loft.devpod
-      - org.gnome.Builder
       - com.getpostman.Postman
       - io.dbeaver.DBeaverCommunity
       - com.github.marhkb.Pods


### PR DESCRIPTION
This probably shouldn't be here.