### PR TITLE
chore(bazaar): block kde apps that are native

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
+++ b/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
@@ -26,3 +26,8 @@ org.kde.dolphin
 dev.lizardbyte.app.Sunshine
 org.freedesktop.fwupd
 org.kde.kate
+org.kde.ark
+org.kde.filelight
+org.kde.kfind
+org.kde.kwalletmanager5
+

--- a/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
+++ b/system_files/shared/usr/share/ublue-os/bazaar/blocklist.txt
@@ -25,3 +25,4 @@ org.kde.konsole
 org.kde.dolphin
 dev.lizardbyte.app.Sunshine
 org.freedesktop.fwupd
+org.kde.kate


### PR DESCRIPTION
Adds KDE applications that we have as native rpm packages to Bazaars blocklist

Ark
Filelight
KFind
Konsole
KWalletManager
Kate

fixes https://github.com/ublue-os/aurora/issues/891