### PR TITLE
fix(bazaar): always use white text color

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -11,14 +11,14 @@ css: |
   }
   .aurora-section banner-text {
      padding: 50px;
-     color: inherit;
+     color: #ffffff;
      text-shadow: 1px 1px 4px rgba(0, 0, 5, 1);
   }
   .aurora-section title {
-     color: inherit;
+     color: #ffffff;
   }
   .aurora-section subtitle {
-    color: inherit;
+    color: #ffffff;
     font-weight: 400;
   }
   .aurora-section {


### PR DESCRIPTION
fixes: https://github.com/ublue-os/aurora/issues/939

<img width="1218" height="854" alt="image" src="https://github.com/user-attachments/assets/5d0578b4-3984-4ee9-97f0-a54bdc523d88" />
<img width="1210" height="898" alt="image" src="https://github.com/user-attachments/assets/88bd85b8-6469-449c-a2cc-96dc25199892" />
