### PR TITLE
chore: remove unneeded dnf5

### DIFF
--- a/build_files/shared/build-base.sh
+++ b/build_files/shared/build-base.sh
@@ -2,13 +2,6 @@
 
 set -eoux pipefail
 
-echo "::group:: ===Install dnf5==="
-if [ "${FEDORA_MAJOR_VERSION}" -lt 41 ]; then
-    rpm-ostree install --idempotent dnf5 dnf5-plugins
-fi
-
-echo "::endgroup::"
-
 echo "::group:: Copy Files"
 
 # Copy ISO list for `install-system-flatpaks`


### PR DESCRIPTION
dnf5 is preinstalled, we don't need to keep stuff from before f41 around

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
