### PR TITLE
fix: changelogs better formatting for authors

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -290,7 +290,7 @@ def get_commits(prev_manifests, manifests, workdir: str):
                 "-C",
                 workdir,
                 "log",
-                "--pretty=format:%H %h %s %an",
+                "--pretty=format:%H|%h|%an|%s",
                 f"{start}..{finish}",
             ],
             check=True,
@@ -301,10 +301,10 @@ def get_commits(prev_manifests, manifests, workdir: str):
         for commit in commits.split("\n"):
             if not commit:
                 continue
-            parts = commit.split(" ", 3)
+            parts = commit.split("|")
             if len(parts) < 4:
                 continue
-            githash, short, subject, author = parts
+            githash, short, author, subject = parts
 
             if subject.lower().startswith("merge"):
                 continue


### PR DESCRIPTION
added some fixes for the authors section, specifially with names (spaces etc)

https://github.com/ublue-os/bazzite/pull/3221

still would  prefer to use github usernames and link the username to their profile but haven't figured out a way to make it work correctly
