### PR TITLE
chore: update docs URL in MOTD template

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/template.md
+++ b/system_files/shared/usr/share/ublue-os/motd/template.md
@@ -13,7 +13,7 @@ Hello, stargazer.
 %TIP%
 
 - **󰊤** [Issues](https://github.com/ublue-os/aurora/issues)
-- **󰈙** [Documentation](https://docs.getaurora.dev/)
+- **󰈙** [Documentation](https://docs.getaurora.dev/guides/software)
 - **󰊌** [Discuss](https://universal-blue.discourse.group/)
 - **󰙯** [Discord](https://discord.com/invite/WEu6BdFEtp)
 


### PR DESCRIPTION
I think we should directly link to a page in the docs. For me, it wasn't clear that I had to click on the "Documentation" text at the top to get to the actual documentation first.

## Current URL

<img width="2880" height="1920" alt="Screenshot_20250917_204324" src="https://github.com/user-attachments/assets/6fd29fff-f182-4dbb-8ce3-237f024935ed" />

Notice that there is no table of contents and it's not clear that there are more pages.

## New URL

<img width="2880" height="1920" alt="Screenshot_20250917_204334" src="https://github.com/user-attachments/assets/e4a7f3f4-82b2-4fc6-a4da-efa979b7017c" />

Much clearer there are a lot more pages IMO.
