### PR TITLE
chore: remove aurora-cli-logos

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,7 +4,6 @@
 			"all": [
 				"adcli",
 				"aurora-backgrounds",
-				"aurora-cli-logos",
 				"aurora-faces",
 				"aurora-fastfetch",
 				"aurora-schemas",


### PR DESCRIPTION
We don't need this, our logo is upstream.
<img width="609" height="931" alt="image" src="https://github.com/user-attachments/assets/79949af3-8b74-451c-82c0-f04bacf0835d" />

https://github.com/fastfetch-cli/fastfetch/issues/1700
