### PR TITLE
chore: remove bcache-tools

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,7 +5,6 @@
 				"adcli",
 				"aurora-backgrounds",
 				"bazaar",
-				"bcache-tools",
 				"borgbackup",
 				"davfs2",
 				"evtest",


### PR DESCRIPTION
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f2c61db29f277b9c80de92102fc532cc247495cd

I don't know why we have this in the first place. No one should be surprised by the way this has been going, I don't care if we remove it with 6.17 or now.
https://github.com/ublue-os/bluefin/pull/1008

