### PR TITLE
fix: Remove Homebrew command-not-found setup script

### DIFF
--- a/just/aurora-apps.just
+++ b/just/aurora-apps.just
@@ -232,57 +232,6 @@ install-gaming-flatpaks:
                                             runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08
 
-# Set up command-not-found for Homebrew
-[group('Apps')]
-setup-brew-not-found ACTION="":
-    #!/usr/bin/env bash
-    source /usr/lib/ujust/ujust.sh
-
-    OPTION={{ ACTION }}
-    if [ "$OPTION" == "help" ]; then
-        echo "Usage: ujust setup-brew-not-found <option>"
-        echo "  <option>: Specify the quick option to skip the prompt"
-        echo "  Use 'enable' to select Enable Brew Not Found"
-        echo "  Use 'disable' to select Disable Brew Not Found"
-        exit 0
-    elif [ "$OPTION" == "" ]; then
-        echo "${bold}Brew command-not-found Setup${normal}"
-        OPTION=$(Choose "Enable Brew command-not-found" "Disable Brew command-not-found")
-    fi
-
-    set -euo pipefail
-
-    BREW_BINARY=/home/linuxbrew/.linuxbrew/bin/brew
-    HOMEBREW_REPOSITORY=${HOMEBREW_REPOSITORY:-$($BREW_BINARY --repository)}
-    if ! $BREW_BINARY -h > /dev/null; then
-      echo "Make sure Homebrew is installed first. Check journalctl -e -u brew-setup.service"
-      exit
-    fi
-
-    if [[ "${OPTION,,}" =~ ^enable ]]; then
-        $BREW_BINARY tap homebrew/command-not-found
-        pkexec tee /etc/profile.d/brew-command-not-found.sh > /dev/null <<EOF
-    # Check for interactive bash or zsh and that we haven't already been sourced
-    if [[ -d /home/linuxbrew/.linuxbrew && \$- == *i* && BREW_COMMAND_NOT_FOUND != 1 ]] ; then
-      HB_CNF_HANDLER="${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
-      [ -f "\$HB_CNF_HANDLER" ] && source "\$HB_CNF_HANDLER"
-      export BREW_COMMAND_NOT_FOUND=1
-    fi
-    EOF
-        # Necessary for fish since just having a script sourcing it does not work
-        pkexec ln -sf "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish" /etc/fish/conf.d/brew-cnf-handler.fish
-        echo "Brew command-not-found has been ${b}${green}enabled${n}"
-    fi
-
-    if [[ "${OPTION,,}" =~ ^disable ]]; then
-        $BREW_BINARY untap homebrew/command-not-found
-        FILES_TO_BE_REMOVED=()
-        [ -f /etc/profile.d/brew-command-not-found.sh ] && FILES_TO_BE_REMOVED+=("/etc/profile.d/brew-command-not-found.sh")
-        [ -f /etc/fish/conf.d/brew-command-not-found.fish ] && FILES_TO_BE_REMOVED+=("/etc/fish/conf.d/brew-command-not-found.fish")
-        pkexec rm -f "${FILES_TO_BE_REMOVED[@]}"
-      echo "Brew command-not-found has been ${b}${red}disabled${n}"
-    fi
-
 # List installed RPM packages of currently booted system
 [group('Apps')]
 list-installed-rpms:


### PR DESCRIPTION
Removed the setup for Homebrew command-not-found. This  seems to have been deprecated in upstream brew

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
