### PR TITLE
fix: Improve argument parsing in kde-ptyxis script

### DIFF
--- a/system_files/shared/usr/bin/kde-ptyxis
+++ b/system_files/shared/usr/bin/kde-ptyxis
@@ -1,7 +1,17 @@
 #!/usr/bin/bash
 # Shim to handle KDE only supporting -e
 # https://bugs.kde.org/show_bug.cgi?id=459616
-args=("${@//-e/--}")
+# We replace all standalone occurrences, but ignore others, e.g. in 'distrobox-enter'
+args=()
+for arg in ${@}; do
+        if [[ "$arg" == -e ]]; then
+                args+=("--")
+        else
+                args+=("$arg")
+        fi
+done
+
+
  
 # Dolphin integration requires --new-window to function properly
 if [[ ! "${args[@]}" =~ "--" && ! "${args[@]}" =~ "-h" && ! "${args[@]}" =~ "-x" ]]; then


### PR DESCRIPTION
Refactor argument handling to replace standalone '-e' with '--'.

Closes https://github.com/ublue-os/aurora/issues/1061

from https://github.com/ublue-os/bazzite/pull/3174/files

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
