### PR TITLE
chore: turn off stable weeklies for F43 prep

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -13,8 +13,8 @@ on:
       - "system_files/shared/usr/share/ublue-os/bazaar/config.yaml"
       - "**.Brewfile"
       - "just/*.just"
-  schedule:
-    - cron: "50 5 * * 0" # 5:50 UTC sunday
+  # schedule:
+  #  - cron: "50 5 * * 0" # 5:50 UTC sunday
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Fedora 43 launches next tuesday (28th). Turning of weekly builds for the time being so wen can land the bigger PRs.

Will run manual weekly build for stable today instead of saturday/sunday

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
