### PR TITLE
feat(bazaar): make tick in gaming section white

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -52,6 +52,10 @@ css: |
     background: linear-gradient(0deg, #444445, #00ce75);
   }
 
+  .gaming-section app-tile-installed-indicator {
+    color: #ffffff;
+  }
+
   .utilities-section {
     background: linear-gradient(to right bottom, #00389e, #1d3283, #242d6a, #262851, #24233a, #282636, #2b2a31, #2d2d2d, #3a3a3a, #474748, #555556, #646364);
   }


### PR DESCRIPTION
not crashing on the old version that is currently shipped with the rpm

#### dark
<img width="1507" height="938" alt="image" src="https://github.com/user-attachments/assets/505f278b-0752-4c9c-b90f-ef90571e63d8" />

#### light
<img width="1507" height="938" alt="image" src="https://github.com/user-attachments/assets/4706caf1-1cea-4a51-9464-b43ba18f7e21" />

#### before:

<img width="1481" height="866" alt="image" src="https://github.com/user-attachments/assets/792084ed-d8f6-44d2-87b5-66d1bb92d2b8" />

