### PR TITLE
feat: remove vorta and solaar from preinstalled apps

### DIFF
--- a/flatpaks/system-flatpaks.list
+++ b/flatpaks/system-flatpaks.list
@@ -1,9 +1,7 @@
-com.borgbase.Vorta
 com.github.tchx84.Flatseal
 com.ranfdev.DistroShelf
 io.github.flattool.Warehouse
 io.github.kolunmi.Bazaar
-io.github.pwr_solaar.solaar
 io.missioncenter.MissionCenter
 org.deskflow.deskflow
 org.fedoraproject.MediaWriter


### PR DESCRIPTION
- Vorta is a borg backup client (for nerds), dejadup is enough as it offers google drive and all that stuff

- solaar is specific to logitech hardware, just put it in bazaar