### PR TITLE
chore: remove umoci

### DIFF
--- a/build_files/dx/03-packages-dx.sh
+++ b/build_files/dx/03-packages-dx.sh
@@ -82,7 +82,6 @@ if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
     copr_install_isolated "ganto/lxc4" "incus" "incus-agent" "lxc"
 fi
 
-copr_install_isolated "ganto/umoci" "umoci"
 copr_install_isolated "karmab/kcli" "kcli"
 copr_install_isolated "gmaglione/podman-bootc" "podman-bootc"
 copr_install_isolated "ublue-os/packages" "ublue-os-libvirt-workarounds"


### PR DESCRIPTION
This copr has been unmaintained since almost a year https://copr.fedorainfracloud.org/coprs/ganto/umoci

If no one seems to have cared about this then let's just remove it This is not available in brew either

```
➜  rpm -qa | grep \.fc41
golang-github-opencontainers-umoci-0.4.7-0.2.fc41.x86_64
```
