### PR TITLE
fix(sunshine): remove sunshine from f43 excluded packages

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -141,7 +141,6 @@ case "$FEDORA_MAJOR_VERSION" in
     43)
         EXCLUDED_PACKAGES+=(
             fw-fanctrl
-            sunshine
             openrazer-daemon
         )
         ;;


### PR DESCRIPTION
Seems we forgor to remove it from the excludes
