### PR TITLE
chore(ci): Disable beta builds

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -1,18 +1,19 @@
 name: Beta Images
 on:
-  merge_group:
-  pull_request:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - "**.md"
-      - "flatpaks/**"
-      - "system_files/etc/bazaar/config.yaml"
-      - "**.Brewfile"
-      - "just/*.just"
-  workflow_call:
-  workflow_dispatch:
+  # All triggers disabled to stop beta builds
+  # merge_group:
+  # pull_request:
+  #   branches:
+  #     - main
+  #     - testing
+  #   paths-ignore:
+  #     - "**.md"
+  #     - "flatpaks/**"
+  #     - "system_files/etc/bazaar/config.yaml"
+  #     - "**.Brewfile"
+  #     - "just/*.just"
+  # workflow_call:
+  # workflow_dispatch:
 
 jobs:
   build-image-beta:


### PR DESCRIPTION
Now that `latest` is on F43, we can disable Betas

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
