### PR TITLE
chore(ISO): Test building the webui iso with :latest

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda-webui.yml
+++ b/.github/workflows/reusable-build-iso-anaconda-webui.yml
@@ -27,11 +27,11 @@ jobs:
       matrix:
         platform: [amd64]
         flavor: ["main", "nvidia-open"]
-        image_version: ["stable"]
+        image_version: ["latest"]
         include:
           - platform: amd64
             flavor: "main"
-            image_version: stable
+            image_version: latest
     permissions:
       contents: read
       packages: read
@@ -101,7 +101,7 @@ jobs:
           path: ${{ steps.rename.outputs.output_directory }}
 
       - name: Upload to CloudFlare
-        if: contains(matrix.image_version, 'stable') && github.event_name != 'pull_request'
+        if: contains(matrix.image_version, 'latest') && github.event_name != 'pull_request'
         shell: bash
         env:
           RCLONE_CONFIG_R2_TYPE: s3


### PR DESCRIPTION
Just a test to see if we can build this on the latest stream to get the newer webui and anaconda packages (which should make the webUI work on KDE)
