### PR TITLE
fix: remove ostree container commit from dx

### DIFF
--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -52,6 +52,4 @@ chmod -R 1777 /var/tmp
 
 # Validate all repos are disabled before committing
 /ctx/build_files/shared/validate-repos.sh
-
-ostree container commit
 echo "::endgroup::"


### PR DESCRIPTION
leftover, bootc container lint does that

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
