### PR TITLE
fix: test if versionlock doesn't cause mismatch

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -15,6 +15,9 @@ source /ctx/build_files/shared/copr-helpers.sh
 # COPR packages are installed individually with isolated enablement.
 
 # Base packages from Fedora repos - common to all versions
+#
+dnf5 versionlock add plasma-desktop
+
 FEDORA_PACKAGES=(
     adcli
     borgbackup


### PR DESCRIPTION
https://github.com/ublue-os/aurora/issues/1227

that means no plasma 6.5 today but tomorrow when our base images have it.
~~Also means latest people will be going back to 6.4.5 unless we revert https://github.com/ublue-os/aurora/pull/1223~~
