### PR TITLE
chore: remove unmaintained app from default applications

### DIFF
--- a/flatpaks/system-flatpaks.list
+++ b/flatpaks/system-flatpaks.list
@@ -8,7 +8,6 @@ org.fedoraproject.MediaWriter
 org.fkoehler.KTailctl
 org.gnome.DejaDup
 org.gtk.Gtk3theme.Breeze
-org.gustavoperedo.FontDownloader
 org.kde.gwenview
 org.kde.haruna
 org.kde.kcalc


### PR DESCRIPTION
Upstream has seen no activity in years, uses an EOL runtime which bloat our ISOs with additonal 500MiB

https://github.com/GustavoPeredo/Font-Downloader

https://github.com/flathub/org.gustavoperedo.FontDownloader/pull/14
