### PR TITLE
chore: remove devpod form default apps

### DIFF
--- a/flatpaks/system-flatpaks-dx.list
+++ b/flatpaks/system-flatpaks-dx.list
@@ -1,4 +1,3 @@
 io.podman_desktop.PodmanDesktop
 io.github.getnf.embellish
 me.iepure.devtoolbox
-sh.loft.devpod


### PR DESCRIPTION
EOL runtime

https://github.com/flathub/sh.loft.devpod/pull/5