### PR TITLE
fix: verify sharship download + pin bash-preexec

### DIFF
--- a/build_files/base/06-override-install.sh
+++ b/build_files/base/06-override-install.sh
@@ -26,8 +26,8 @@ unzip /tmp/nerdfontsymbols.zip -d /tmp
 mkdir -p /usr/share/fonts/nerd-fonts/NerdFontsSymbolsOnly/
 mv /tmp/SymbolsNerdFont*.ttf /usr/share/fonts/nerd-fonts/NerdFontsSymbolsOnly/
 
-# Bash Prexec
-curl --retry 3 -Lo /usr/share/bash-prexec https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh
+# Bash Prexec v0.6.0
+ghcurl https://raw.githubusercontent.com/rcaloras/bash-preexec/b73ed5f7f953207b958f15b1773721dded697ac3/bash-preexec.sh --retry 3 -Lo /usr/share/bash-prexec
 
 # Caps
 setcap 'cap_net_raw+ep' /usr/libexec/ksysguard/ksgrd_network_helper


### PR DESCRIPTION
I don't think we should ship some random bash script directly from master branch, not sure what problem this script fixes in the first place but we can discuss that in the future.