### PR TITLE
fix(ujust): toggle-dinosaurs incorrect qdbus binary name

### DIFF
--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -265,7 +265,7 @@ toggle-dinosaurs hemisphere="north":
                 echo "The wallpaper will update automatically each month."
                 filename="$HOME/.local/share/wallpapers/Bluefin/{{ hemisphere }}.avif"
 
-                qdbus org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "
+                qdbus-qt6 org.kde.plasmashell /PlasmaShell org.kde.PlasmaShell.evaluateScript "
                     var allDesktops = desktops();
                     for (var i = 0; i < allDesktops.length; i++) {
                         var d = allDesktops[i];


### PR DESCRIPTION
Verified that this works.

Closes https://github.com/ublue-os/aurora/issues/1288,