### PR TITLE
fix(ptyxis): patch for handling dead keys on KDE

### DIFF
--- a/build_files/base/06-override-install.sh
+++ b/build_files/base/06-override-install.sh
@@ -61,7 +61,7 @@ sed -i 's@\[Desktop Action new-window\]@\[Desktop Action new-window\]\nX-KDE-Sho
 sed -i 's@Exec=ptyxis@Exec=kde-ptyxis@g' /usr/share/applications/org.gnome.Ptyxis.desktop
 sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop
 # GTK 4.20 changed how it handles input methods; see https://github.com/ghostty-org/ghostty/discussions/8899#discussioncomment-14717979
-sed -i 's|Exec=ptyxis|Exec=env GTK_IM_MODULE=ibus ptyxis|g' /usr/share/applications/org.gnome.Ptyxis.desktop
+desktop-file-edit --set-key=Exec --set-value='env GTK_IM_MODULE=ibus ptyxis' /usr/share/applications/org.gnome.Ptyxis.desktop
 cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/
 
 rm -f /etc/profile.d/gnome-ssh-askpass.{csh,sh} # This shouldn't be pulled in


### PR DESCRIPTION
GTK 4.20 changed way it handles input methods:
https://github.com/ublue-os/bazzite/commit/967f8f60db64947b610bb1d50a226304cb23e506 
https://github.com/ghostty-org/ghostty/discussions/8899#discussioncomment-14717979

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
