### PR TITLE
fix(ci): fix fedora_version detection

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -739,7 +739,7 @@ fedora_version image="aurora" tag="latest" flavor="main" $kernel_pin="":
             skopeo inspect --retry-times 3 docker://ghcr.io/ublue-os/base-main:"{{ tag }}" > /tmp/manifest.json
         fi
     fi
-    fedora_version=$(jq -r '.Labels["ostree.linux"]' < /tmp/manifest.json | grep -oP 'fc\K[0-9]+')
+    fedora_version=$(jq -r '.Labels["org.opencontainers.image.version"]' < /tmp/manifest.json | grep -oP '^[0-9]+')
     if [[ -n "${kernel_pin:-}" ]]; then
         fedora_version=$(echo "${kernel_pin}" | grep -oP 'fc\K[0-9]+')
     fi

--- a/just/aurora-system.just
+++ b/just/aurora-system.just
@@ -36,7 +36,6 @@ benchmark:
 aurora-cli:
     @/usr/libexec/ublue-bling
 
-
 # alias for install-fonts
 aurora-fonts:
     @ujust install-fonts


### PR DESCRIPTION
This should now fix the issue with fedora_version after the coreOS43 update. f.ex https://github.com/ublue-os/aurora/actions/runs/19416700187/job/55546241246?pr=1307#step:9:23

Can't test for  stable because of zfs but atleast it gets over the fedora_version check
