### PR TITLE
feat(ci): utilize all the space from the btrfs action

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -39,6 +39,10 @@ jobs:
         stream_name: ["${{ inputs.stream_name }}"]
 
     steps:
+      - name: Show space
+        run: |
+          df -h
+
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
       # mount /mnt as /var/lib/containers

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -115,4 +115,7 @@ for unit in "${IMPORTANT_UNITS[@]}"; do
     fi
 done
 
+# remove me
+df -h
+
 echo "::endgroup::"


### PR DESCRIPTION
See:
https://github.com/ublue-os/container-storage-action#loopback-free

https://github.com/ublue-os/aurora/actions/runs/19402404727/job/55511791559#step:9:4582

let's hope we get those empty runners soon

We now have 65 GiB instead of 52
<img width="577" height="156" alt="image" src="https://github.com/user-attachments/assets/4793d561-cb0f-4e64-9b90-d56c4214a597" />