### PR TITLE
fix(ci): go back to unwanted-software-action

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda-webui.yml
+++ b/.github/workflows/reusable-build-iso-anaconda-webui.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Maximize build space
         if: matrix.platform != 'arm64'
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
-        with:
-          remove-codeql: true
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -41,8 +41,6 @@ jobs:
       - name: Maximize build space
         if: matrix.platform != 'arm64'
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
-        with:
-          remove-codeql: true
 
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5

--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
-        with:
-          remove-codeql: true
 
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,8 +44,6 @@ jobs:
 
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
-        with:
-          remove-codeql: true
 
       - name: Setup Just
         uses: extractions/setup-just@e33e0265a09d6d736e2ee1e0eb685ef1de4669ff # v3


### PR DESCRIPTION
as discussed in:
#1314

this is not as bad as I thought it was gonna be, using the new revised v10 that nukes like everything, taking about 20s-1min.
The old v9 took like 3mins