### PR TITLE
chore: remove cosign from the image

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -132,6 +132,7 @@ copr_install_isolated "lizardbyte/beta" \
 
 # Packages to exclude - common to all versions
 EXCLUDED_PACKAGES=(
+    cosign
     fedora-bookmarks
     fedora-chromium-config
     fedora-chromium-config-kde


### PR DESCRIPTION
we add this in main as part of:
https://github.com/ublue-os/main/blob/80cdd1654fc74bf1531a4f4c67b2ae8c0c3b07f7/build_files/install.sh#L150

Installing an RPM from github releases

We save 150MiB with this. Our pipeline handles the signing of the images and if users want to sign images then they can use cosign from homebrew, chainguard container + distrobox.

<img width="387" height="359" alt="image" src="https://github.com/user-attachments/assets/1043798a-ed39-4411-b42f-84d1d5265a60" />
