### PR TITLE
chore: cleanup broken symlinks

### DIFF
--- a/system_files/shared/etc/xdg/kcm-about-distrorc
+++ b/system_files/shared/etc/xdg/kcm-about-distrorc
@@ -1,1 +1,0 @@
-../../usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc

--- a/system_files/shared/etc/xdg/kdeglobals
+++ b/system_files/shared/etc/xdg/kdeglobals
@@ -1,1 +1,0 @@
-../../usr/share/kde-settings/kde-profile/default/xdg/kdeglobals

--- a/system_files/shared/etc/xdg/krunnerrc
+++ b/system_files/shared/etc/xdg/krunnerrc
@@ -1,1 +1,0 @@
-../../usr/share/kde-settings/kde-profile/default/xdg/krunnerrc

--- a/system_files/shared/etc/xdg/kwinrc
+++ b/system_files/shared/etc/xdg/kwinrc
@@ -1,1 +1,0 @@
-../../usr/share/kde-settings/kde-profile/default/xdg/kwinrc


### PR DESCRIPTION
These symlinks were not even copied to the final images. They would fail with:
skipping non-regular file "etc/xdg/kcm-about-distrorc

See:
https://github.com/ublue-os/aurora/actions/runs/19692850390/job/56412087989#step:10:264

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
