### PR TITLE
feat: add back uld samsung/hp printer driver

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -57,6 +57,7 @@ FEDORA_PACKAGES=(
     sssd-ipa
     sssd-krb5
     tmux
+    uld
     virtualbox-guest-additions
     wireguard-tools
     wl-clipboard
@@ -68,7 +69,6 @@ case "$FEDORA_MAJOR_VERSION" in
     42)
         FEDORA_PACKAGES+=(
             google-noto-fonts-all
-            uld
         )
         ;;
     43)


### PR DESCRIPTION
fixes: https://github.com/ublue-os/aurora/issues/1404 This is a proprietary driver from negativo repo.
We had this in the past and this is hardware enablement so I think it's fine to include (again).

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
