### PR TITLE
fix(ujust): remove broken configure-broadcom-wl recipe

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -8,4 +8,8 @@ set -eoux pipefail
 mkdir -p /usr/share/ublue-os/aurora-cli
 cp /usr/share/ublue-os/bling/* /usr/share/ublue-os/aurora-cli
 
+# Remove the akmods recipes from ujust, which at the moment only contains
+# the broken broadcom wl module recipe
+sed -i 's|^import "/usr/share/ublue-os/just/50-akmods.just"|#import "/usr/share/ublue-os/just/50-akmods.just"|' /usr/share/ublue-os/justfile
+
 echo "::endgroup::"


### PR DESCRIPTION
The broadcom `wl` module was removed in https://github.com/ublue-os/aurora/pull/291, but the `ujust` recipe `configure-broadcom-wl` still exists, causing confusion with users.

This PR comments out the `include` directive for the justfile containing the broadcom recipe. For reference, this is the content of that file:

```bash
❯ cat /usr/share/ublue-os/just/50-akmods.just
# vim: set ft=make :

alias broadcom-wl := configure-broadcom-wl

# Configure Broadcom WL driver (Enabling WL breaks numerous other Wi-Fi adapters)
configure-broadcom-wl ACTION="prompt":
    #!/usr/bin/bash
    source /usr/lib/ujust/ujust.sh
    OPTION={{ ACTION }}
    if [ "$OPTION" == "prompt" ]; then
      echo "${bold}Configuring Broadcom Wi-Fi${normal}"
      echo 'Enabling Broadcom WL driver will break numerous other Wi-Fi adapters.'
      echo 'Enable or Disable Broadcom Wl?'
      OPTION=$(ugum choose Enable Disable)
    elif [ "$OPTION" == "help" ]; then
      echo "Usage: ujust configure-broadcom-wl <option>"
      echo "  <option>: Specify the quick option - 'enable' or 'disable'"
      echo "  Use 'enable' to select Enable"
      echo "  Use 'disable' to select Disable"
      exit 0
    fi
    if [ "${OPTION,,}" == "enable" ]; then
      sudo rm -f /etc/modprobe.d/broadcom-wl-blacklist.conf
      sudo rm -f /etc/modprobe.d/default-disable-broadcom-wl.conf
      echo "${bold}Enabled${normal} Broadcom Wireless, please reboot for changes to take effect"
    elif [ "${OPTION,,}" == "disable" ]; then
      sudo ln -sf /dev/null /etc/modprobe.d/broadcom-wl-blacklist.conf
      sudo bash -c 'echo "blacklist wl" > /etc/modprobe.d/default-disable-broadcom-wl.conf'
      echo "${bold}Disabled${normal} Broadcom Wireless, please reboot for changes to take effect"
    fi
```

Closes https://github.com/ublue-os/aurora/issues/1419.