### PR TITLE
fix: update Ptyxis dbus activation to use correct shim

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -12,4 +12,8 @@ cp /usr/share/ublue-os/bling/* /usr/share/ublue-os/aurora-cli
 # the broken broadcom wl module recipe
 sed -i 's|^import "/usr/share/ublue-os/just/50-akmods.just"|#import "/usr/share/ublue-os/just/50-akmods.just"|' /usr/share/ublue-os/justfile
 
+# Force Ptyxis version opened via dbus (e.g., keyboard shortcut) to use the proper shim
+# https://github.com/ublue-os/bazzite/pull/3620
+sed -i 's@Exec=/usr/bin/ptyxis@Exec=/usr/bin/kde-ptyxis@g' /usr/share/dbus-1/services/org.gnome.Ptyxis.service
+
 echo "::endgroup::"


### PR DESCRIPTION
Pulling in https://github.com/ublue-os/bazzite/pull/3620 to address issue described in https://github.com/ublue-os/bazzite/issues/3482, which also applies to Aurora.