### PR TITLE
fix: unbreak dx-builds

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -139,8 +139,11 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
-for i in /etc/yum.repos.d/rpmfusion-*; do
-    sed -i 's@enabled=1@enabled=0@g' "$i"
+# Disable RPM Fusion repos
+for i in /etc/yum.repos.d/rpmfusion-*.repo; do
+    if [[ -f "$i" ]]; then
+        sed -i 's@enabled=1@enabled=0@g' "$i"
+    fi
 done
 
 echo "::endgroup::"


### PR DESCRIPTION
main removed
```
rpmfusion-nonfree-nvidia-driver.repo
rpmfusion-nonfree-steam.repo
```

https://github.com/ublue-os/main/pull/1841

```
  sed: can't read /etc/yum.repos.d/rpmfusion-*: No such file or directory

```
same as: 
https://github.com/ublue-os/bluefin/pull/3861