### PR TITLE
feat: set CMD as /sbin/init

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -40,4 +40,6 @@ RUN --mount=type=tmpfs,dst=/boot \
     --mount=type=secret,id=GITHUB_TOKEN \
     /ctx/build_files/shared/build.sh
 
+CMD ["/sbin/init"]
+
 RUN bootc container lint


### PR DESCRIPTION
According to bootc docs it is recommended to be set.

See:
https://bootc-dev.github.io/bootc/building/bootc-runtime.html

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
