### PR TITLE
fix: cleanup /tmp

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -14,6 +14,7 @@ rm -rf /.gitkeep
 # https://bootc-dev.github.io/bootc/filesystem.html#filesystem
 find /var -mindepth 1 -delete
 find /boot -mindepth 1 -delete
-mkdir -p /var /boot
+find /tmp -mindepth 1 -delete
+mkdir -p /var /boot /tmp
 
 echo "::endgroup::"


### PR DESCRIPTION
hhd/rechunk previously cleaned this up, so we never noticed and had leftovers of 600MiB on our image. This is needed when we move off of this rechunker implementation.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
