### PR TITLE
fix: move starship init bash to /etc/profile.d

### DIFF
--- a/system_files/shared/etc/profile.d/90-aurora-starship.sh
+++ b/system_files/shared/etc/profile.d/90-aurora-starship.sh
@@ -1,6 +1,0 @@
-# shellcheck shell=sh
-command -v starship >/dev/null 2>&1 || return 0
-
-if [ "$(basename "$(readlink /proc/$$/exe)")" = "bash" ]; then
-  eval "$(starship init bash)"
-fi


### PR DESCRIPTION
We are currently not doing anything with Fish and therefore also not initting starship. So Fish has the default prompt and no change in behavior there.

Fixes: https://github.com/ublue-os/aurora/issues/1518

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
