### PR TITLE
feat: switch over to brew OCI from RPM

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,8 +4,11 @@ ARG SOURCE_IMAGE="${BASE_IMAGE_NAME}-main"
 ARG BASE_IMAGE="ghcr.io/ublue-os/${SOURCE_IMAGE}"
 ARG COMMON_IMAGE="ghcr.io/get-aurora-dev/common:latest"
 ARG COMMON_IMAGE_SHA=""
+ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
+ARG BREW_IMAGE_SHA=""
 
 FROM ${COMMON_IMAGE}@${COMMON_IMAGE_SHA} AS common
+FROM ${BREW_IMAGE}@${BREW_IMAGE_SHA} AS brew
 
 FROM scratch AS ctx
 COPY /build_files /build_files
@@ -16,6 +19,9 @@ COPY --from=common /flatpaks /flatpaks
 COPY --from=common /logos /logos
 COPY --from=common /system_files /system_files
 COPY --from=common /wallpapers /system_files/shared
+
+# https://github.com/ublue-os/brew
+COPY --from=brew /system_files /system_files/shared
 
 # Overwrite files from common if necessary
 COPY /system_files /system_files

--- a/Justfile
+++ b/Justfile
@@ -1,6 +1,7 @@
 repo_organization := "ublue-os"
 rechunker_image := "ghcr.io/ublue-os/legacy-rechunk:v1.0.0-x86_64@sha256:1ee0b4ad0eee9b300cca1afd8cf78b78ce77bcc0d5aa16b07a195c6c22f1c9b4"
 common_image := "ghcr.io/get-aurora-dev/common:latest"
+brew_image := "ghcr.io/ublue-os/brew:latest"
 images := '(
     [aurora]=aurora
     [aurora-dx]=aurora-dx
@@ -105,6 +106,7 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
 
     common_image_sha=$(yq -r '.images[] | select(.name == "common") | .digest' image-versions.yml)
+    brew_image_sha=$(yq -r '.images[] | select(.name == "brew") | .digest' image-versions.yml)
 
     # Base Image
     base_image_name="kinoite"
@@ -145,6 +147,8 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
 
     {{ just }} verify-container "common:latest@${common_image_sha}" ghcr.io/get-aurora-dev https://raw.githubusercontent.com/get-aurora-dev/common/refs/heads/main/cosign.pub
 
+    {{ just }} verify-container "brew:latest@${brew_image_sha}"
+
     # Get Version
     if [[ "${tag}" =~ stable ]]; then
         ver="${fedora_version}.$(date +%Y%m%d)"
@@ -174,6 +178,8 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     BUILD_ARGS+=("--build-arg" "BASE_IMAGE_NAME=${base_image_name}")
     BUILD_ARGS+=("--build-arg" "COMMON_IMAGE={{ common_image }}")
     BUILD_ARGS+=("--build-arg" "COMMON_IMAGE_SHA=${common_image_sha}")
+    BUILD_ARGS+=("--build-arg" "BREW_IMAGE={{ brew_image }}")
+    BUILD_ARGS+=("--build-arg" "BREW_IMAGE_SHA=${brew_image_sha}")
     BUILD_ARGS+=("--build-arg" "FEDORA_MAJOR_VERSION=${fedora_version}")
     BUILD_ARGS+=("--build-arg" "IMAGE_NAME=${image_name}")
     BUILD_ARGS+=("--build-arg" "IMAGE_VENDOR={{ repo_organization }}")

--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -104,7 +104,6 @@ copr_install_isolated "ublue-os/staging" \
 copr_install_isolated "ublue-os/packages" \
     "krunner-bazaar" \
     "kcm_ublue" \
-    "ublue-brew" \
     "uupd"
 
 # Version-specific COPR packages

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -44,6 +44,7 @@ test -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service && false
 flatpak preinstall --help
 
 test -f /usr/share/doc/aurora/aurora.pdf
+test -f /usr/share/homebrew.tar.zst
 
 desktop-file-validate \
   /usr/share/applications/Discourse.desktop \

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -7,3 +7,7 @@ images:
     image: ghcr.io/get-aurora-dev/common
     tag: latest
     digest: sha256:0340f545fc87cc4a7a244d79bbf228b864d8404a4c1288289ae8705e0646ccfb
+  - name: brew
+    image: ghcr.io/ublue-os/brew
+    tag: latest
+    digest: sha256:1a59be4ce5415e7028c84b5550290c8e773f57bcfcfb2b2a0d8dc75473ecfe65


### PR DESCRIPTION
This new brew version also includes those 2 changes:

https://github.com/ublue-os/brew/pull/2
https://github.com/ublue-os/brew/pull/1

Brew binaries have less priority than system binaries now.

This will also make our image update deltas 120MiB bigger as hhd/rechunker doesn't handle non-RPM content at all, unlike the rpm-ostree compose build-chunked-oci. It's gonna suck until the blockers are resolved for this to be properly handled.

https://github.com/ublue-os/brew

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
