### PR TITLE
fix: missing udev rules

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -148,8 +148,6 @@ EXCLUDED_PACKAGES=(
     plasma-discover-kns
     plasma-welcome-fedora
     podman-docker
-    ublue-os-luks
-    ublue-os-udev-rules
 )
 
 # Version-specific package exclusions

--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -9,7 +9,7 @@ install -Dm0644 -t /etc/ublue-os/ /ctx/flatpaks/*.list
 
 # We need to remove this package here because lots of files we add from `projectbluefin/common` override the rpm files and they also go away when you do `dnf remove`
 # TODO: this can be removed whenever we stop doing FROM ublue-os/kinoite-main
-dnf remove -y ublue-os-just ublue-os-signing
+dnf remove -y ublue-os-just ublue-os-signing ublue-os-udev-rules ublue-os-luks
 
 # Copy Files to Container
 rsync -rvKl /ctx/system_files/shared/ /


### PR DESCRIPTION
We were overwriting files we derive from kinoite-main and then removing the ones that are overlapping between the two, resulting in missing udev rules. This basically goes for all ublue* packages that kinoite-main includes, so also moved ublue-os-luks.

Fixes: https://github.com/ublue-os/aurora/issues/1530

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
