### PR TITLE
feat(ci): re-enable SBOM generation

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -126,7 +126,7 @@ jobs:
           OUTPUT_PATH="$(mktemp -d)/sbom.json"
           export SYFT_PARALLELISM=$(($(nproc)*2))
           sudo $SYFT_CMD --source-name "${IMAGE}"-"${STREAM_NAME}" --select-catalogers=rpm ${OCI_DIR} -o spdx-json=${OUTPUT_PATH}
-          cat ${OUTPUT_PATH}
+          ls -lh ${OUTPUT_PATH}
           echo "OUTPUT_PATH=${OUTPUT_PATH}" >> $GITHUB_OUTPUT
           sudo rm -rf ${OCI_DIR}
 


### PR DESCRIPTION
Other methods of generating it causes the runner to run out of memory.

<img width="1271" height="319" alt="image" src="https://github.com/user-attachments/assets/c39cd2f3-6991-490d-82cc-5a937bf1b008" />



test with
```
cosign verify-attestation --type spdxjson --key ~/git/ublue-os/cosign.pub ghcr.io/renner0e/aurora:latest@sha256:9d53e51073ca799eb6d5d0b548eee2df18fc41c2af4cb1e88f602c4ca88f31aa --output json | jq -r '.payload | @base64d | fromjson | .predicate' > sbom.json
```
https://github.com/renner0e/diffuse/blob/main/cosign.pub

related issues:
https://github.com/ublue-os/bluefin-lts/pull/484
https://github.com/secureblue/secureblue/issues/1298
https://github.com/anchore/syft/issues/3800
https://github.com/ublue-os/aurora/issues/1545