### PR TITLE
fix(ci): include everything in sbom

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -125,8 +125,8 @@ jobs:
 
           OUTPUT_PATH="$(mktemp -d)/sbom.json"
           export SYFT_PARALLELISM=$(($(nproc)*2))
-          sudo $SYFT_CMD --source-name "${IMAGE}"-"${STREAM_NAME}" --select-catalogers=rpm ${OCI_DIR} -o spdx-json=${OUTPUT_PATH}
-          ls -lh ${OUTPUT_PATH}
+          sudo $SYFT_CMD --source-name "${IMAGE}"-"${STREAM_NAME}" ${OCI_DIR} -o syft-json=${OUTPUT_PATH}
+          du -sh ${OUTPUT_PATH}
           echo "OUTPUT_PATH=${OUTPUT_PATH}" >> $GITHUB_OUTPUT
           sudo rm -rf ${OCI_DIR}
 


### PR DESCRIPTION
This extra information doesn't seem to crash runners and includes way more useful information we need for the changelogs.

Follow up of: https://github.com/ublue-os/aurora/pull/1548

needed for: https://github.com/ublue-os/aurora/pull/1557

helps with: https://github.com/ublue-os/aurora/issues/1487

working run can be seen here:
https://github.com/renner0e/aurora/actions/runs/20638987899/job/59268028196

example usage:

```
cosign download attestation ghcr.io/renner0e/aurora:latest | jq -r '.payload' | base64 -d | jq -r "." > sbom.json
```

```
...
          "size": 31261673,
          "sourceRpm": "plasma-desktop-6.5.4-2.fc43.src.rpm",
          "vendor": "Fedora Project",
          "version": "6.5.4"
        },
        "metadataType": "rpm-db-entry",
        "name": "plasma-desktop",
        "purl": "pkg:rpm/plasma-desktop@6.5.4-2.fc43?arch=x86_64&upstream=plasma-desktop-6.5.4-2.fc43.src.rpm",
        "type": "rpm",
        "version": "6.5.4-2.fc43"
      },
...
```