### PR TITLE
chore: cleanup ublue-guest-user.service

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -11,7 +11,6 @@ set -eoux pipefail
 systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable dconf-update.service
-systemctl enable ublue-guest-user.service
 systemctl enable brew-setup.service
 systemctl enable brew-upgrade.timer
 systemctl enable brew-update.timer


### PR DESCRIPTION
we don't need this, this was like a docker ephemeral user thing, running aurora graphical session inside docker

needs: https://github.com/get-aurora-dev/common/pull/74

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
