### PR TITLE
chore: delete bootc install config

### DIFF
--- a/system_files/shared/usr/lib/bootc/install/20-aurora.toml
+++ b/system_files/shared/usr/lib/bootc/install/20-aurora.toml
@@ -1,2 +1,0 @@
-[install]
-root-fs-type = "btrfs"


### PR DESCRIPTION
This used to be needed for the readymade installer, this can now be specified from the CLI.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
