### PR TITLE
fix: disable rpm-ostreed-automatic.timer

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -36,6 +36,9 @@ systemctl --global disable sunshine.service
 # Updater
 systemctl enable uupd.timer
 
+# Disable the old update timer
+systemctl disable rpm-ostreed-automatic.timer
+
 # Hide Desktop Files. Hidden removes mime associations
 for file in htop nvtop; do
     if [[ -f "/usr/share/applications/${file}.desktop" ]]; then


### PR DESCRIPTION
related to https://github.com/ublue-os/aurora/pull/1571/

the rpm-ostreed-automatic.timer gets enabled and currently the image has uupd.timer and the old rpm-ostreed-automatic.timer enabled.

Seems the ublue-os-update-services package only actually has the flatpak update timers in the package and just config files for the rpm-ostreed-automatic.timer (or overrides to be specific)
