### PR TITLE
chore(brew): dont explicitly enable brew-{update,upgrade} timers

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -12,8 +12,6 @@ systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable dconf-update.service
 systemctl enable brew-setup.service
-systemctl enable brew-upgrade.timer
-systemctl enable brew-update.timer
 systemctl enable aurora-groups.service
 systemctl enable usr-share-sddm-themes.mount
 systemctl enable ublue-system-setup.service

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -132,8 +132,6 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
 fi
 
 IMPORTANT_UNITS=(
-    brew-update.timer
-    brew-upgrade.timer
     rpm-ostree-countme.timer
     tailscaled.service
     ublue-system-setup.service


### PR DESCRIPTION
We don't need this as we use `uupd` for handling brew updates and we have a systemd preset for this

Related: https://github.com/ublue-os/bluefin/pull/3988
Related: https://github.com/projectbluefin/common/issues/121
