### PR TITLE
fix: generate ISO checksums after renaming

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda-webui.yml
+++ b/.github/workflows/reusable-build-iso-anaconda-webui.yml
@@ -100,8 +100,8 @@ jobs:
           set -x
           mkdir -p output
           OUTPUT_DIRECTORY="$(realpath output)"
-          sha256sum "${OUTPUT_PATH}" | tee "${OUTPUT_DIRECTORY}/${OUTPUT_NAME}.iso-CHECKSUM"
           mv "${OUTPUT_PATH}" "${OUTPUT_DIRECTORY}/${OUTPUT_NAME}.iso"
+          (cd "${OUTPUT_DIRECTORY}" && sha256sum "${OUTPUT_NAME}.iso" | tee "${OUTPUT_NAME}.iso-CHECKSUM")
           echo "output_directory=$OUTPUT_DIRECTORY" >> "${GITHUB_OUTPUT}"
 
       - name: Upload to Job Artifacts


### PR DESCRIPTION
Fix https://github.com/ublue-os/aurora/issues/1636

This was once already fixed with #993 but only on the old workflow