### PR TITLE
fix: add gvfs

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -89,6 +89,7 @@ FEDORA_PACKAGES=(
     google-noto-sans-sundanese-fonts
     grub2-tools-extra
     gum
+    gvfs
     heif-pixbuf-loader
     htop
     icoutils


### PR DESCRIPTION
This is needed for applications like dejadup which interface with various gvfs backends.

Related: https://gitlab.gnome.org/World/deja-dup/-/issues/630

Fixes: https://github.com/ublue-os/aurora/issues/1638

Tested with dejadup + webdav backend which runs on my nextcloud server.

This needed a reboot to create `$XDG_RUNTIME_DIR/gvfs`