### PR TITLE
fix: add gvfs-fuse

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -90,6 +90,7 @@ FEDORA_PACKAGES=(
     grub2-tools-extra
     gum
     gvfs
+    gvfs-fuse
     heif-pixbuf-loader
     htop
     icoutils


### PR DESCRIPTION
Seems that only gvfs isn't enough in some cases

followup of: https://github.com/ublue-os/aurora/pull/1639

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
