### PR TITLE
fix: logos package conflict on downstream images

### DIFF
--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -4,8 +4,12 @@ set -eoux pipefail
 
 echo "::group:: Copy Files"
 
-# We need to remove this package here because lots of files we add from `{projectbluefin,get-aurora-dev}/common` override the rpm files and they also go away when you do `dnf remove`
-rpm --erase --nodeps fedora-logos
+# We need to remove this package here because lots of files we add from `{projectbluefin,get-aurora-dev}/common` override the rpm files
+# they go away when you do dnf remove
+# Keep *-logos in RPM DB for downstream package installations
+# We are not allowed to ship an empty fedora-logos package
+dnf -y swap fedora-logos generic-logos
+rpm --erase --nodeps --nodb generic-logos
 
 # Copy Files to Container
 rsync -rvKl /ctx/system_files/shared/ /


### PR DESCRIPTION
Not having *-logos leads to conclicts and will either break package
layering (file already exists) or completely replace them if used in
downstream images if a single package like anaconda requires them.

To comply with the licensing of the fedora-logos we have to swap it out
for the generic-logos.

"This package and its content may not be distributed with anything but
unmodified packages from Fedora Project. It can be used in a Fedora Spin,
but not in a Fedora Remix. If necessary, this package can be replaced by
the more liberally licensed generic-logos package."

By swapping it out with the generic-logos we can get away with not
making a dummy package, allowing these "problematic" packages to be installed
on downstream images and keep using OCI/non-RPM for our branding.

Fixes: https://github.com/ublue-os/bluefin/issues/4048