### PR TITLE
chore: do not set cap_net_raw=ep for ksysguard

### DIFF
--- a/build_files/base/06-override-install.sh
+++ b/build_files/base/06-override-install.sh
@@ -48,9 +48,6 @@ mkdir -p /usr/lib/systemd/system-generators
 ghcurl "https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator" --retry 3 -Lo /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 chmod +x /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 
-# Caps
-setcap 'cap_net_raw+ep' /usr/libexec/ksysguard/ksgrd_network_helper
-
 # ######
 # BASE IMAGE CHANGES
 # ######


### PR DESCRIPTION
This got fixed in Fedora:
https://src.fedoraproject.org/rpms/libksysguard/c/babc3a3502afbd328969649b7dc8f52ed7ef08bc?branch=rawhide

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
