### PR TITLE
refactor: split up build.sh

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -38,13 +38,116 @@ ARG UBLUE_IMAGE_TAG="stable"
 ARG VERSION=""
 ARG IMAGE_FLAVOR=""
 
-# Build, cleanup, lint.
+# Prep
 RUN --mount=type=tmpfs,dst=/boot \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
     --mount=type=secret,id=GITHUB_TOKEN \
     /ctx/build_files/shared/build.sh
 
-# Makes `/opt` writeable by default
+# so ghcurl wrapper is available to all later RUNs
+ENV PATH="/tmp/scripts/helpers:${PATH}"
+
+# Generate image-info.json, os-release
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    /ctx/build_files/base/00-image-info.sh
+
+# Install Kernel and Akmods
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    /ctx/build_files/base/03-install-kernel-akmods.sh
+
+# Install Additional Packages
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    /ctx/build_files/base/04-packages.sh
+
+# Wallpapers/Apperance
+RUN --network=none \
+    --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build_files/base/05-branding.sh
+
+# Install Overrides and Fetch Install
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    /ctx/build_files/base/06-override-install.sh
+
+# Get Firmare for Framework
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    /ctx/build_files/base/08-firmware.sh
+
+# Beta
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    if [ "${UBLUE_IMAGE_TAG}" == "beta" ] ; then \
+      /ctx/build_files/base/10-beta.sh; \
+    fi
+
+# Enable systemd services and Remove Items
+RUN --network=none \
+    --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    /ctx/build_files/base/17-cleanup.sh
+
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    /ctx/build_files/base/18-workarounds.sh
+
+# Regenerate initramfs
+RUN --network=none \
+    --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build_files/base/19-initramfs.sh
+
+# Aurora-DX
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    if [ "${IMAGE_FLAVOR}" == "dx" ] ; then \
+      /ctx/build_files/shared/build-dx.sh; \
+    fi
+
+RUN --mount=type=tmpfs,dst=/boot \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    --mount=type=cache,dst=/var/cache/libdnf5 \
+    --mount=type=secret,id=GITHUB_TOKEN \
+    if [ "${IMAGE_FLAVOR}" == "dx" ] ; then \
+      /ctx/build_files/dx/00-dx.sh; \
+    fi
+
+RUN --network=none \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build_files/shared/validate-repos.sh
+
+RUN --network=none \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build_files/shared/clean-stage.sh
+
+# Sanity checks
+RUN --network=none \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build_files/base/20-tests.sh
+
+RUN --network=none \
+    --mount=type=bind,from=ctx,source=/,target=/ctx \
+    if [ "${IMAGE_FLAVOR}" == "dx" ] ; then \
+      /ctx/build_files/dx/10-tests-dx.sh; \
+    fi
+
 # Needs to be here to make the main image build strict (no /opt there)
 # This is for downstream images/stuff like k0s
 RUN rm -rf /opt && ln -s /var/opt /opt

--- a/build_files/base/06-override-install.sh
+++ b/build_files/base/06-override-install.sh
@@ -4,6 +4,9 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
+# Enable Flathub
+flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+
 # Footgun, See: https://github.com/ublue-os/main/issues/598
 rm -f /usr/bin/chsh /usr/bin/lchsh
 

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -44,8 +44,6 @@ for file in htop nvtop; do
     fi
 done
 
-#Add the Flathub Flatpak remote and remove the Fedora Flatpak remote
-flatpak remote-add --system --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 systemctl disable flatpak-add-fedora-repos.service
 
 # NOTE: With isolated COPR installation, most repos are never enabled globally.

--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -7,10 +7,6 @@ echo "::group:: Copy Files"
 # Copy Files to Image
 rsync -rvK /ctx/system_files/dx/ /
 
-mkdir -p /tmp/scripts/helpers
-install -Dm0755 /ctx/build_files/shared/utils/ghcurl /tmp/scripts/helpers/ghcurl
-export PATH="/tmp/scripts/helpers:$PATH"
-
 echo "::endgroup::"
 
 # Apply IP Forwarding before installing Docker to prevent messing with LXC networking
@@ -25,15 +21,5 @@ tee /etc/modules-load.d/ip_tables.conf <<EOF
 iptable_nat
 EOF
 
-# Install Packages and setup DX
-/ctx/build_files/dx/00-dx.sh
-
 # Branding Changes
 echo "Variant=Developer Experience" >> /usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
-
-# Validate all repos are disabled before committing
-/ctx/build_files/shared/validate-repos.sh
-echo "::endgroup::"
-
-# dx specific tests
-/ctx/build_files/dx/10-tests-dx.sh

--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -4,6 +4,9 @@ set -eoux pipefail
 
 echo "::group:: Copy Files"
 
+# Speeds up local builds
+dnf config-manager setopt keepcache=1
+
 # We need to remove this package here because lots of files we add from `{projectbluefin,get-aurora-dev}/common` override the rpm files
 # they go away when you do dnf remove
 # Keep *-logos in RPM DB for downstream package installations
@@ -16,52 +19,5 @@ rsync -rvKl /ctx/system_files/shared/ /
 
 mkdir -p /tmp/scripts/helpers
 install -Dm0755 /ctx/build_files/shared/utils/ghcurl /tmp/scripts/helpers/ghcurl
-export PATH="/tmp/scripts/helpers:$PATH"
 
 echo "::endgroup::"
-
-# Generate image-info.json, os-release
-/ctx/build_files/base/00-image-info.sh
-
-# Install Kernel and Akmods
-/ctx/build_files/base/03-install-kernel-akmods.sh
-
-# Install Additional Packages
-/ctx/build_files/base/04-packages.sh
-
-# Wallpapers/Apperance
-/ctx/build_files/base/05-branding.sh
-
-# Install Overrides and Fetch Install
-/ctx/build_files/base/06-override-install.sh
-
-# Get Firmare for Framework
-/ctx/build_files/base/08-firmware.sh
-
-# Beta
-# /ctx/build_files/base/10-beta.sh
-
-## late stage changes
-
-# Systemd and Remove Items
-/ctx/build_files/base/17-cleanup.sh
-
-# Run workarounds for lf (Likely not needed)
-/ctx/build_files/base/18-workarounds.sh
-
-# Regenerate initramfs
-/ctx/build_files/base/19-initramfs.sh
-
-if [ "${IMAGE_FLAVOR}" == "dx" ] ; then
-  # Now we build DX!
-  /ctx/build_files/shared/build-dx.sh
-fi
-
-# Validate all repos are disabled before committing
-/ctx/build_files/shared/validate-repos.sh
-
-# Clean Up
-/ctx/build_files/shared/clean-stage.sh
-
-# Simple Tests
-/ctx/build_files/base/20-tests.sh

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -4,17 +4,22 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
+# Revert back to upstream defaults
+dnf config-manager setopt keepcache=0
+
 # This comes last because we can't *ever* afford to ship fedora flatpaks on the image
 systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 
 rm -rf /.gitkeep
 
-# We can clean those up, they are "discarded" by bootc anyway
 # https://bootc-dev.github.io/bootc/filesystem.html#filesystem
-find /var -mindepth 1 -delete
-find /boot -mindepth 1 -delete
-find /tmp -mindepth 1 -delete
-mkdir -p /var /boot /tmp
+rm -rf /{var,tmp,boot}
+mkdir -p /{var,tmp,boot}
+find /run/* -maxdepth 0 -type d \
+  \! -name .containerenv \
+  \! -name secrets \
+  \! -name systemd \
+  -exec rm -fr {} \;
 
 echo "::endgroup::"


### PR DESCRIPTION
Aside from the separation of all the scripts to make use of container build cache, there is now a package cache for dnf which will speed up local builds quite a bit and allow us to disable networking on some steps of the build.

There is still room for improvement here by juggling a couple steps around and eliminate 1 or 2 scripts here and the handling of akmods as we are currently *always* fetching them no matter what.

fixes: https://github.com/ublue-os/aurora/issues/1195

2 ACKs would be nice