### PR TITLE
fix: set variant properly in os-release and KDE

### DIFF
--- a/build_files/base/00-image-info.sh
+++ b/build_files/base/00-image-info.sh
@@ -37,6 +37,11 @@ EOF
 # OS Release File
 sed -i "s|^VARIANT_ID=.*|VARIANT_ID=$IMAGE_NAME|" /usr/lib/os-release
 sed -i "s|^PRETTY_NAME=.*|PRETTY_NAME=\"${IMAGE_PRETTY_NAME} (Version: ${VERSION})\"|" /usr/lib/os-release
+
+if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
+  sed -i "s|^RELEASE_TYPE=.*|RELEASE_TYPE=${UBLUE_IMAGE_TAG}|" /usr/lib/os-release
+fi
+
 sed -i "s|^NAME=.*|NAME=\"$IMAGE_PRETTY_NAME\"|" /usr/lib/os-release
 sed -i "s|^HOME_URL=.*|HOME_URL=\"$HOME_URL\"|" /usr/lib/os-release
 sed -i "s|^DOCUMENTATION_URL=.*|DOCUMENTATION_URL=\"$DOCUMENTATION_URL\"|" /usr/lib/os-release
@@ -58,6 +63,9 @@ fi
 # https://www.freedesktop.org/software/systemd/man/latest/os-release.html#IMAGE_ID=
 echo "IMAGE_ID=\"${IMAGE_NAME}\"" >> /usr/lib/os-release
 echo "IMAGE_VERSION=\"${VERSION}\"" >> /usr/lib/os-release
+
+# Debugging
+cat /usr/lib/os-release
 
 # Fix issues caused by ID no longer being fedora
 sed -i "s|^EFIDIR=.*|EFIDIR=\"fedora\"|" /usr/sbin/grub2-switch-to-blscfg

--- a/build_files/base/10-beta.sh
+++ b/build_files/base/10-beta.sh
@@ -4,12 +4,4 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
-
-if ! jq -e '.["image-tag"] | test("beta|latest")' /usr/share/ublue-os/image-info.json >/dev/null; then
-    echo "We only run this on latest and beta"
-    exit 0
-fi
-
-
-
 echo "::endgroup::"


### PR DESCRIPTION
The standard value derived from fedora here is set to stable, this only
makes sense to deviate from on our beta images as the latest image tag
as RELEASE_TYPE would be awkward.