### PR TITLE
add kdepim-addons

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -102,6 +102,7 @@ FEDORA_PACKAGES=(
     just
     kate
     kcm-fcitx5
+    kdepim-addons
     krb5-workstation
     ksshaskpass
     ksystemlog


### PR DESCRIPTION
adds package kdepim-addons to enable digital clock widget to display events and calendars that are setup systemwide (through kontact, google drive, nextcloud etc). 

resolves #1614 