### PR TITLE
fix: only remove /usr/share/doc/HTML

### DIFF
--- a/build_files/base/06-override-install.sh
+++ b/build_files/base/06-override-install.sh
@@ -17,8 +17,8 @@ sed -Ei "s/secure_path = (.*)/secure_path = \1:\/home\/linuxbrew\/.linuxbrew\/bi
 # https://github.com/ublue-os/main/pull/334
 ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
-# Documentation is available online
-rm -rf /usr/share/doc
+# KDE Documentation is available online
+rm -rf /usr/share/doc/HTML
 
 # Offline Aurora documentation
 ghcurl "https://github.com/ublue-os/aurora-docs/releases/download/0.1/aurora.pdf" --retry 3 -o /tmp/aurora.pdf


### PR DESCRIPTION
This removed some license files, these are probably fedora packaging bugs as they should be in /usr/share/licenses according to:

https://docs.fedoraproject.org/en-US/packaging-guidelines/LicensingGuidelines/#_license_text

Instead of saving roughly 200MiB we would only save 60MiB instead. Explicitly not deleting those files and/or fixing Fedora packages would be a huge effort/maintainence nightmare.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
