### PR TITLE
test: check if packages are from negativo

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -100,6 +100,23 @@ for package in "${IMPORTANT_PACKAGES[@]}"; do
     rpm -q "${package}" >/dev/null || { echo "Missing package: ${package}... Exiting"; exit 1 ; }
 done
 
+# these should be sourced from negativo's fedora-multimedia repo
+# as Fedora can't ship patent encumbered video codecs
+NEGATIVO=(
+    ffmpeg
+    libheif
+    libva
+    mesa-filesystem
+    mesa-va-drivers
+    pipewire-libs-extra
+    x264-libs
+    x265-libs
+)
+
+for package in "${NEGATIVO[@]}"; do
+  rpm -q --qf "%{NAME} %{VENDOR}" "${package}" | grep -q "negativo17\.org" || { echo "${package} not from negativo... Exiting"; exit 1 ; }
+done
+
 # these packages are supposed to be removed
 # and are considered footguns
 UNWANTED_PACKAGES=(


### PR DESCRIPTION
This should prevent cases like:
https://github.com/ublue-os/aurora/pull/1693
from happening again where cerain silent package conflicts cause codec/mesa related packages to be installed from Fedora instead of negativo.

These packages picked here are rather arbitrary and based on previous experiences in the past.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
