### PR TITLE
fix(renovate): don't bump on major fedora versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -42,6 +42,11 @@
         "ghcr.io/ublue-os/brew",
         "ghcr.io/get-aurora-dev/common"
       ]
+    },
+    {
+      "matchDepNames": ["quay.io/fedora-ostree-desktops/kinoite"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
We only care when the current Fedora (43) digest gets updated. Renovate should not make these sorts of updates.

See: https://github.com/ublue-os/aurora/pull/1723

https://github.com/ublue-os/renovate-sandbox/pull/66 got autoclosed so this rule should work.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
