### PR TITLE
chore: use btrfs action again

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -45,7 +45,7 @@ jobs:
       # mount /mnt as /var/lib/containers
       - name: Mount BTRFS for podman storage
         id: container-storage-action
-        uses: ublue-os/container-storage-action@8795b9b5dc8c520b1a56227a543cd5bac6181f2b
+        uses: ublue-os/container-storage-action@25e05be4948f77746938687877829d15c5038036
         continue-on-error: true
         with:
           target-dir: /var/lib/containers


### PR DESCRIPTION
There are some A/B testing shenanigans going on here, the size of the backing disks in github runners varies.

See: https://github.com/ublue-os/container-storage-action/issues/14

Effectively reverts commit 49ede339693749c01d3a5ec19186771efdd780ad.

spotted in:
https://github.com/ublue-os/aurora/actions/runs/21873790245/job/63136593985?pr=1476

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
