### PR TITLE
fix: turn off bazaar.service

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -23,7 +23,7 @@ systemctl enable input-remapper.service
 systemctl enable flatpak-nuke-fedora.service
 
 # TODO: Reinvestigate when bazaar gains dbus activation
-systemctl --global enable bazaar.service
+# systemctl --global enable bazaar.service
 
 # run flatpak preinstall once at startup
 systemctl enable flatpak-preinstall.service


### PR DESCRIPTION
This has been an ever-growing pain in the past few weeks especially. Users sometimes were hit with random timeouts that no one could ever figure out the cause for. This means that search results for bazaar will only appear in krunner when it has been explicitly started by the user beforehand.

Best to disable it and leave the option to enable it if desired.

See: https://github.com/get-aurora-dev/common/pull/113

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
