### PR TITLE
chore: organize negativo packages in a separate list

### DIFF
--- a/build_files/base/03-packages.sh
+++ b/build_files/base/03-packages.sh
@@ -90,7 +90,6 @@ FEDORA_PACKAGES=(
     gum
     gvfs
     gvfs-fuse
-    heif-pixbuf-loader
     htop
     icoutils
     ifuse


### PR DESCRIPTION
This is more maintainable as it is easier to figure out which packages
we are getting from which repo.

chore: remove heif-pixbuf-loader

This package is not in Fedora or Negativo in F43, it was part of the
libheif subpackage in F42. It was silently not getting installed.
