### PR TITLE
chore: pin kernel to 6.17.12

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["aurora"]
     with:
-      #kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.17.12-300.fc43.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
We can unpin again when we have openzfs 2.4.1

See: https://github.com/ublue-os/akmods/pull/453

Undraft/merge when everything looks fine in the logs