### PR TITLE
feat(ci): setup DNF package cache

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -81,6 +81,16 @@ jobs:
           echo "Default Tag: ${DEFAULT_TAG}"
           echo "DEFAULT_TAG=${DEFAULT_TAG}" >> $GITHUB_ENV
 
+      - name: Setup DNF package cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        with:
+          path: /var/tmp/buildah-cache-*
+          key: ${{ runner.os }}-buildah-${{ env.IMAGE_NAME }}
+          restore-keys: |
+            ${{ runner.os }}-buildah-${{ env.IMAGE_NAME }}
+
       - name: Build Image
         id: build-image
         shell: bash
@@ -309,6 +319,12 @@ jobs:
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${LOWERCASE}/${IMAGE_NAME}@${SBOM_DIGEST}
+
+      # https://github.com/actions/cache/issues/1533
+      - name: Hack around permission issue caching
+        id: cache-perms
+        run: |
+          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
 
   check:
     name: Check all ${{ matrix.stream_name }} builds successful


### PR DESCRIPTION
This uses https://github.com/actions/cache, this should avoid repulling
packages from the Fedora repositories every time we rebuild, downloading
them from Github is minimally faster from my testing.

This pulls in the package cache before every build and uploads the new
cache again (with new packages) so it can be reused on later runs. It's
kinda janky as the first image i.e. aurora-dx-nvidia-open :stable and
:latest are competing with each other basically as they have the same
image name. Only one job run can write to the same cache (we have four
of those). So there will be some inefficiencies as some runs won't
upload packages. But the only difference should be nvidia specific
things and rocm which we only install on our regular images. So it's
not perfect in any way. But this is easy to revert so I say we just try
it.

All this is possible because we set
--mount=type=cache,dst=/var/cache/libdnf5 and keepcache=1 for dnf.