### PR TITLE
chore: remove redundant dbus-x11

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -28,7 +28,6 @@ FEDORA_PACKAGES=(
     cockpit-selinux
     cockpit-storaged
     cockpit-system
-    dbus-x11
     edk2-ovmf
     flatpak-builder
     incus


### PR DESCRIPTION
this is on the base image already

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
