### PR TITLE
chore: rename just readme

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -11,6 +11,9 @@ dnf config-manager setopt keepcache=0
 systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 
+# reinvestigate when https://github.com/ostreedev/ostree/pull/3559 reached fedora
+mv '/usr/share/doc/just/README.中文.md' '/usr/share/doc/just/README.zh-cn.md'
+
 rm -rf /.gitkeep
 
 # https://bootc-dev.github.io/bootc/filesystem.html#filesystem


### PR DESCRIPTION
Creating a bootable image with bootc install fails if we don't have this.

looks like: https://github.com/ostreedev/ostree/issues/3431

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
