### PR TITLE
chore: remove old way to modify panel pinned apps

### DIFF
--- a/build_files/base/16-override-install.sh
+++ b/build_files/base/16-override-install.sh
@@ -21,15 +21,6 @@ rm -rf /usr/share/doc/HTML
 # BASE IMAGE CHANGES
 # ######
 
-# sets default/pinned applications on the taskmanager applet on the panel, there is no nice way to do this
-# https://bugs.kde.org/show_bug.cgi?id=511560
-# TODO: KDE 6.6 dropped this file, find out some other way to set these
-PANEL_CONF="/usr/share/plasma/plasmoids/org.kde.plasma.taskmanager/contents/config/main.xml"
-
-if [[ -f "${PANEL_CONF}" ]]; then
-  sed -i '/<entry name="launchers" type="StringList">/,/<\/entry>/ s/<default>[^<]*<\/default>/<default>preferred:\/\/browser,applications:org.gnome.Ptyxis.desktop,applications:io.github.kolunmi.Bazaar.desktop,preferred:\/\/filemanager<\/default>/' "${PANEL_CONF}"
-fi
-
 # Hide Discover entries by renaming them (allows for easy re-enabling)
 discover_apps=(
   "org.kde.discover.desktop"


### PR DESCRIPTION
Plasma 6.6 changed the way this is done, this config file doesn't exist anymore

See:
https://github.com/get-aurora-dev/common/pull/118
https://bugs.kde.org/show_bug.cgi?id=511560

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
