### PR TITLE
fix: restore copr.vendor.conf

### DIFF
--- a/system_files/shared/usr/lib/dnf/plugins/copr.vendor.conf
+++ b/system_files/shared/usr/lib/dnf/plugins/copr.vendor.conf
@@ -1,0 +1,19 @@
+# This override is to handle the default behavior of dnf5 using ID at /etc/os-release
+# to select which chroot gets used to fetch the copr repo.
+#
+# An example of the behavior displayed without this override in Bazzite:
+# sudo dnf5 copr enable ublue-os/bling
+#  https://copr.fedorainfracloud.org/api_3/rpmrepo/ublue-os/bling/bazzite-41/                          100% | 946.0   B/s | 500.0   B |  00m01s
+# Chroot not found in the given Copr project (bazzite-41-x86_64).                                                                              You can choose one of the available chroots explicitly:
+#  fedora-38-x86_64
+#  fedora-39-x86_64
+#  fedora-40-x86_64
+#  fedora-41-x86_64
+#  fedora-rawhide-x86_64
+#
+# See:
+#   https://github.com/rpm-software-management/dnf5/blob/01d4df824ff4a94ae1fc288f81923d02ba71173a/dnf5-plugins/copr_plugin/copr_config.cpp#L79-L81
+#   https://github.com/rpm-software-management/dnf5/blob/01d4df824ff4a94ae1fc288f81923d02ba71173a/dnf5-plugins/copr_plugin/copr_repo.cpp#L146
+
+[main]
+distribution = fedora


### PR DESCRIPTION
This was accidentally removed in 0880b9d, this broke custom images.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
