### PR TITLE
chore: unpin kernel from 6.17.12

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["aurora"]
     with:
-      kernel_pin: 6.17.12-300.fc43.x86_64 ## This is where kernels get pinned.
+      #kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Reverts ublue-os/aurora#1752

New ZFS is now released