### PR TITLE
fix: workaround selinux issues which breaks image updates

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -79,7 +79,6 @@ FEDORA_PACKAGES=(
     fish
     flatpak-spawn
     foo2zjs
-    freeipa-client
     git-credential-libsecret
     glow
     google-noto-sans-balinese-fonts


### PR DESCRIPTION
Huge thanks @RoyalOughtness!

This will make everyone's updates work again without manual intervention on the user side like temporarily setting selinux to permissive.

Due to incorrect selinux labeling of /usr/libexec/sssd/passkey_child which is part of the sssd-passkey package (which is a weak dependency of freeipa-client). Rebasing/upgrading from an image containing selinux-policy-42.24 and sssd-passkey-2.12.0 into an image that that also contains sssd-passkey but has been moved to a different image layer (due to rechunking plan changes for example), which causes ostree to import the layer again, hitting the following issues:

```
bootc[108075]: Pulling new image: ostree-unverified-image:containers-storage:localhost/aurora:latest-chunked
audit[108075]: AVC avc:  denied  { getattr } for  pid=108075 comm="tokio-runtime-w" path="/sysroot/ostree/repo/objects/b4/d5d0043441967922c4eedd55d7fd4ff3c601a3f2579d17f6059dd99d017f10.file" dev="dm-0" ino=101603553 scontext=unconfined_u:system_r:install_t:s0-s0:c0.c1023 tcontext=system_u:object_r:sssd_mfa_exec_t:s0 tclass=file permissive=0
```

```
error: Importing: Checking out base commit: Opening content object b4d5d0043441967922c4eedd55d7fd4ff3c601a3f2579d17f6059dd99d017f10: openat: Permission denied
```

Removing these packages will lead to the removal of the following, which will break SSSD functionality:

```
augeas-libs-1.14.2-0.6.20250415gitaf2aa88.fc43.x86_64
autofs-1:5.1.9-10.fc43.x86_64
certmonger-0.79.21-1.fc43.x86_64
freeipa-client-4.13.1-5.fc43.x86_64
freeipa-client-common-4.13.1-5.fc43.noarch
freeipa-client-encrypted-dns-4.13.1-5.fc43.x86_64
freeipa-common-4.13.1-5.fc43.noarch
freeipa-selinux-4.13.1-5.fc43.noarch
libjose-14-5.fc43.x86_64
nss-tools-3.119.1-1.fc43.x86_64
python3-argcomplete-3.6.3-2.fc43.noarch
python3-augeas-1.2.0-6.fc43.x86_64
python3-decorator-5.2.1-5.fc43.noarch
python3-deprecated-1.3.1-1.fc43.noarch
python3-gssapi-1.7.3-15.fc43.x86_64
python3-ifaddr-0.2.0-4.fc43.noarch
python3-ipaclient-4.13.1-5.fc43.noarch
python3-ipalib-4.13.1-5.fc43.noarch
python3-jinja2-3.1.6-6.fc43.noarch
python3-jwcrypto-1.4.2-16.fc43.noarch
python3-ldap-3.4.5-1.fc43.x86_64
python3-libipa_hbac-2.12.0-1.fc43.x86_64
python3-markupsafe-3.0.2-6.fc43.x86_64
python3-netaddr-1.3.0-10.fc43.noarch
python3-pyasn1-0.6.2-1.fc43.noarch
python3-pyasn1-modules-0.6.2-1.fc43.noarch
python3-pypng-0.0.21-15.fc43.noarch
python3-pyusb-1.3.1-6.fc43.noarch
python3-qrcode-8.0-9.fc43.noarch
python3-qrcode+all-8.0-9.fc43.noarch
python3-sss-2.12.0-1.fc43.x86_64
python3-sss-murmur-2.12.0-1.fc43.x86_64
python3-sssdconfig-2.12.0-1.fc43.noarch
python3-systemd-235-17.fc43.x86_64
python3-wrapt-1.17.1-6.fc43.x86_64
python3-yubico-1.3.3-22.fc43.noarch
sssd-dbus-2.12.0-1.fc43.x86_64
sssd-idp-2.12.0-1.fc43.x86_64
sssd-passkey-2.12.0-1.fc43.x86_64
sssd-tools-2.12.0-1.fc43.x86_64
unbound-1.24.2-1.fc43.x86_64
unbound-utils-1.24.2-1.fc43.x86_64
```

resolves: https://github.com/ublue-os/aurora/issues/1809

upstream issue: https://github.com/fedora-selinux/selinux-policy/issues/3081

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
