### PR TITLE
fix: clear all versionlocks

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -6,6 +6,7 @@ set -eoux pipefail
 
 # Revert back to upstream defaults
 dnf config-manager setopt keepcache=0
+dnf versionlock clear
 
 # This comes last because we can't *ever* afford to ship fedora flatpaks on the image
 systemctl mask flatpak-add-fedora-repos.service


### PR DESCRIPTION
We are using multiple versionlocks for Plasma, QT and the various kernel packages to prevent further upgrades during the build as they would otherwise cause numerous issues like partial upgrades which can lead to crashes.

This also makes it less annoying to consume Aurora as a base in a derived image.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
