### PR TITLE
feat(ci): upload OCI Archive for PR testing

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -240,6 +240,22 @@ jobs:
 
             echo "digest=${digest}" >> $GITHUB_OUTPUT
 
+      - name: Upload OCI dir as Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: ${{ env.IMAGE_NAME }}.oci
+          path: ${{ env.IMAGE_NAME }}_build
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: PR Testing Instructions
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Download an image, run unzip aurora.oci.zip -d aurora" >> $GITHUB_STEP_SUMMARY
+          echo "Rebase to them: sudo bootc switch --transport oci /absolute/path/to/dir/aurora" >> $GITHUB_STEP_SUMMARY
+          echo "Go back: sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/aurora" >> $GITHUB_STEP_SUMMARY
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Lowers the barrier to testing PRs a little bit as you don't have to build an image locally anymore and is a good compromise in my opinion as we would avoid using production signing keys for PR builds that should probably be cleaned up more aggressively than the usual 90 days.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
