### PR TITLE
chore(beta): remove discover

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -230,8 +230,8 @@ EXCLUDED_PACKAGES=(
     mariadb
     mariadb-common
     mariadb-errmsg
-    plasma-discover-kns
-    plasma-discover-rpm-ostree
+    plasma-discover
+    plasma-discover-libs
     plasma-welcome-fedora
     podman-docker
 )

--- a/build_files/base/16-override-install.sh
+++ b/build_files/base/16-override-install.sh
@@ -21,22 +21,7 @@ rm -rf /usr/share/doc/HTML
 # BASE IMAGE CHANGES
 # ######
 
-# Hide Discover entries by renaming them (allows for easy re-enabling)
-discover_apps=(
-  "org.kde.discover.desktop"
-  "org.kde.discover.flatpak.desktop"
-  "org.kde.discover.notifier.desktop"
-  "org.kde.discover.urlhandler.desktop"
-)
-
-for app in "${discover_apps[@]}"; do
-  if [ -f "/usr/share/applications/${app}" ]; then
-    mv "/usr/share/applications/${app}" "/usr/share/applications/${app}.disabled"
-  fi
-done
-
-# These notifications are useless and confusing
-rm /etc/xdg/autostart/org.kde.discover.notifier.desktop
+rm -f /usr/lib64/qt6/plugins/kf6/krunner/krunner_appstream.so
 
 # Use Bazaar for Flatpak refs
 # Force Ptyxis version opened via dbus (e.g., keyboard shortcut) to use the proper shim

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -128,8 +128,7 @@ UNWANTED_PACKAGES=(
     fedora-logos
     fedora-third-party
     firefox
-    plasma-discover-kns
-    plasma-discover-rpm-ostree
+    plasma-discover
     plasma-lookandfeel-fedora
     podman-docker
 )


### PR DESCRIPTION
-libs is currently not removed with the base package

See: https://bugzilla.redhat.com/show_bug.cgi?id=2417275

fixes: https://github.com/ublue-os/aurora/issues/1703

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
