### PR TITLE
chore: get nvidia rpms from akmods, remove i686

### DIFF
--- a/build_files/base/nvidia.sh
+++ b/build_files/base/nvidia.sh
@@ -7,9 +7,7 @@ set -eoux pipefail
 # Not available for Fedora 43 yet
 dnf config-manager setopt excludepkgs=golang-github-nvidia-container-toolkit
 
-ghcurl "https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh" -o /tmp/nvidia-install.sh
-chmod +x /tmp/nvidia-install.sh
-IMAGE_NAME="${BASE_IMAGE_NAME}" RPMFUSION_MIRROR="" AKMODNV_PATH="/tmp/rpms/nvidia" /tmp/nvidia-install.sh
+IMAGE_NAME="${BASE_IMAGE_NAME}" AKMODNV_PATH="/tmp/rpms/nvidia" MULTILIB=0 /tmp/rpms/nvidia/ublue-os/nvidia-install.sh
 rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
 ln -sf libnvidia-ml.so.1 /usr/lib64/libnvidia-ml.so
 tee /usr/lib/bootc/kargs.d/00-nvidia.toml <<EOF


### PR DESCRIPTION
This means we don't have to download the nvidia stuff anymore as it
comes bundled with the nvidia akmods and should be a little more
reliable in general.

We don't need 32-bit libraries on the host, people should use Steam and
friends from Flathub and distrobox, this makes the nvidia images
roughly 800MiB lighter.

needs: https://github.com/ublue-os/akmods/pull/457