### PR TITLE
chore: remove starship

### DIFF
--- a/build_files/base/03-fetch.sh
+++ b/build_files/base/03-fetch.sh
@@ -20,14 +20,6 @@ curl -X 'GET' \
 'https://flathub.org/api/v2/stats/io.github.kolunmi.Bazaar?all=false&days=1' \
 -H 'accept: application/json' | jq -r ".installs_last_7_days" | numfmt --to=si --round=nearest > /usr/share/ublue-os/bazaar-install-count
 
-# Starship Shell Prompt
-ghcurl "https://github.com/starship/starship/releases/latest/download/starship-$(uname -m)-unknown-linux-gnu.tar.gz" --retry 3 -o /tmp/starship.tar.gz
-ghcurl "https://github.com/starship/starship/releases/latest/download/starship-$(uname -m)-unknown-linux-gnu.tar.gz.sha256" --retry 3 -o /tmp/starship.tar.gz.sha256
-
-echo "$(cat /tmp/starship.tar.gz.sha256) /tmp/starship.tar.gz" | sha256sum --check
-tar -xzf /tmp/starship.tar.gz -C /tmp
-install -c -m 0755 /tmp/starship /usr/bin
-
 # Nerdfont symbols
 # to fix motd and prompt atleast temporarily
 ghcurl "https://github.com/ryanoasis/nerd-fonts/releases/latest/download/NerdFontsSymbolsOnly.zip" --retry 3 -o /tmp/nerdfontsymbols.zip


### PR DESCRIPTION
Starship can be installed with homebrew, for multi user systems you can either setup the shared linuxbrew group or download the binary from the github releases and drop it in /usr/local/bin as that is wriable or ~/.local/bin.

fixes: https://github.com/ublue-os/aurora/issues/1742

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
