### PR TITLE
fix: pin rpm-ostree to 2025.12-1

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -286,6 +286,9 @@ dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test install flat
 #    dnf5 upgrade --refresh --advisory=FEDORA-2024-dd2e9fb225
 #fi
 
+# https://github.com/coreos/rpm-ostree/issues/5567
+dnf -y install rpm-ostree-2025.12-1.fc$(rpm -E %fedora)
+
 # Explicitly install KDE Plasma related packages with the same version as in base image
 if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
   dnf -y copr enable @kdesig/kde-beta


### PR DESCRIPTION
https://github.com/coreos/rpm-ostree/issues/5567

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
