### PR TITLE
fix: clear out content in /{var,tmp}

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -145,5 +145,4 @@ CMD ["/sbin/init"]
 
 RUN --network=none \
     --mount=type=tmpfs,dst=/run \
-    --mount=type=tmpfs,dst=/tmp \
     bootc container lint

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -17,6 +17,10 @@ mv '/usr/share/doc/just/README.中文.md' '/usr/share/doc/just/README.zh-cn.md'
 
 rm -rf /.gitkeep
 
+find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
+rm -rf /tmp/*
+mkdir -p /var/tmp
+
 # Needs to be here to make the main image build strict (no /opt there)
 # This is for downstream images/stuff like k0s
 rm -rf /opt && ln -s /var/opt /opt


### PR DESCRIPTION
fixup of https://github.com/ublue-os/aurora/pull/1846

/tmp wasn't supposed to be in the RUN statement, this only hid those files from `bootc container lint`, they still make it into the final image. We basically don't care about anything else in /var other than cache.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
