### PR TITLE
chore: set artifact retention to 1 day

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -263,7 +263,7 @@ jobs:
           name: ${{ env.IMAGE_NAME }}.oci
           path: ${{ env.IMAGE_NAME }}_build
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 1
 
       - name: PR Testing Instructions
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
To avoid us hitting some sort of limit imposed by GitHub in the future, 1 day is more than enough to test things. We can also just rebuild to get a fresh artifact so these can be short lived.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
