### PR TITLE
chore: workaround for rpm-ostreed.conf getting overwritten

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -286,8 +286,13 @@ dnf5 -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test install flat
 #    dnf5 upgrade --refresh --advisory=FEDORA-2024-dd2e9fb225
 #fi
 
+# This can all be removed when
+# https://bodhi.fedoraproject.org/updates/FEDORA-2026-b0568b39a2
+# made it into our base image
 # https://github.com/coreos/rpm-ostree/issues/5567
-dnf -y install rpm-ostree-2025.12-1.fc$(rpm -E %fedora)
+dnf -y install rpm-ostree-2025.12-1.fc"$(rpm -E %fedora)"
+# workaround for https://github.com/coreos/rpm-ostree/issues/5573
+cp /ctx/system_files/shared/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
 
 # Explicitly install KDE Plasma related packages with the same version as in base image
 if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -15,6 +15,9 @@ BACKUP_KEY=$(jq -r '.transports.docker."ghcr.io/ublue-os"[0].keyPaths[1]' /etc/c
 KEY1_SHA256="af78ecfda6eb21c35195af3739341715e9cfc3f2f5911dd9c10b0670547bf6e8"
 BACKUP_KEY_SHA256="b723467015ba562d40b4645c98c51c65d8254bb59444f6e9962debcfe2315da0"
 
+RPM_OSTREED_CONF_SHA256="f48bb2359e9c31ed464127048138993e2e058bb648e5fd9ba7b7386a2b5eb174"
+echo "${RPM_OSTREED_CONF_SHA256}  /etc/rpm-ostreed.conf" | sha256sum -c -
+
 echo "${KEY1_SHA256}  ${KEY1}" | sha256sum -c -
 echo "${BACKUP_KEY_SHA256}  ${BACKUP_KEY}" | sha256sum -c -
 


### PR DESCRIPTION
A packaging bug in rpm-ostree overwites /etc/rpm-ostreed.conf during
the build but this should not be happening as we are modifying this
file and doesn't match up anymore with whatever is shipped in the RPM and thus
should not get overwritten by installing packages.

This didn't break anything for us as far as I could tell due to us using
uupd and not relying on rpm-ostreed-automatic.service but we should
still set this correctly. Even tho a fix is on the way.

https://bodhi.fedoraproject.org/updates/FEDORA-2026-b0568b39a2

I didn't find a nice way to validate this config file so I did it the
stupid way. In the future we might want to think about copying all the
files at the end of the build as common should not contain any files
that are necessary to have during the build.