### PR TITLE
chore(ci): switch away from change-string-case-action

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -223,9 +223,10 @@ jobs:
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry
         id: registry_case
-        uses: ASzc/change-string-case-action@d0603cd0a7dd490be678164909f65c7737470a7f # v6
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
+        env:
+          IMAGE_REGISTRY: ${{ env.IMAGE_REGISTRY }}
+        run: |
+          echo "lowercase=${IMAGE_REGISTRY,,}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
An action for a single lin in bash is kinda insane

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
