### PR TITLE
feat: add autofs

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -60,6 +60,7 @@ FEDORA_PACKAGES=(
     alsa-firmware
     apr
     apr-util
+    autofs
     borgbackup
     davfs2
     distrobox


### PR DESCRIPTION
Allows defining fstab-like mounts for network filesystems to be mounted on-demand.

- [Kernel.org documentation](https://docs.kernel.org/filesystems/autofs.html)
- [Configuring AutoFS on Fedora 38](https://reintech.io/blog/configuring-autofs-on-fedora-38), clearly illustrates how to use and the advantages over plain `fstab` entries.