### PR TITLE
fix(beta): add mariadb back

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -227,9 +227,6 @@ EXCLUDED_PACKAGES=(
     khelpcenter
     krfb
     krfb-libs
-    mariadb
-    mariadb-common
-    mariadb-errmsg
     plasma-discover-kns
     plasma-discover-rpm-ostree
     plasma-welcome-fedora


### PR DESCRIPTION
When rebasing from our kinoite base image to aurora:beta the ostree deployment will fail with this error:

```
libsemanage.semanage_direct_get_module_info: Unable to open
mariadb-plugin-cracklib-password-check module lang ext file at
/etc/selinux/targeted/tmp/modules/200/mariadb-plugin-cracklib-password-check/lang_ext.
(No such file or directory).
```

Adding mariadb-cracklib-password-check back to our image resolves this issue.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
