### PR TITLE
fix(ci): run scorecard once per week with stable

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -7,6 +7,7 @@ on:
      paths-ignore:
        - "**.md"
        - ".github/workflows/moderator.yml"
+       - ".github/workflows/scorecard.yml"
    workflow_call:
    workflow_dispatch:
 

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"
+      - ".github/workflows/scorecard.yml"
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -8,6 +8,7 @@ on:
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"
+      - ".github/workflows/scorecard.yml"
   schedule:
     - cron: "0 1 * * TUE" # Every Tuesday at 1:15 AM
   workflow_call:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -10,7 +10,7 @@ on:
   # To guarantee Maintained check is occasionally updated. See
   # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
   schedule:
-    - cron: '* * 1/7 * *'
+    - cron: "0 1 * * TUE" # Every Tuesday at 1:15 AM
   push:
     branches: [ "main" ]
 


### PR DESCRIPTION
This wasn't supposed to run at every 15 minutes

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
