### PR TITLE
fix(ci): actually hardcode the cache restore key to aurora-dx

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -717,13 +717,15 @@ setup-cache $image="aurora" $ghcr="0" $github_event="0":
 
     ALLOW_CACHE_WRITE="false"
 
-    if [[ "${image_name}" == "aurora-dx" ]] && \
+    BLESSED_IMAGE=aurora-dx
+
+    if [[ "${image_name}" == "${BLESSED_IMAGE}" ]] && \
        [[ "{{ ghcr }}" == "1" ]] && \
        [[ "${github_event}" == "workflow_dispatch" || "${github_event}" == "schedule" ]]; then
         ALLOW_CACHE_WRITE="true"
     fi
 
-    CACHE_NAME="${image_name}"-"${fedora_version}"
+    CACHE_NAME="${BLESSED_IMAGE}-${fedora_version}"
 
     echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
 


### PR DESCRIPTION
We are writing cache to the proper location but not adjusting the restore keys properly, i.e. aurora wants to look for cache at aurora even tho we are purposefully only allowing aurora-dx cache to be created.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
