### PR TITLE
fix(ci): make cache use proper fedora version

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -95,9 +95,11 @@ jobs:
         id: setup-cache
         env:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           CACHE="$(just setup-cache "${MATRIX_BASE_NAME}" \
+                            "${MATRIX_STREAM_NAME}" \
                             "1" \
                             "${GITHUB_EVENT_NAME}")"
 

--- a/Justfile
+++ b/Justfile
@@ -708,12 +708,12 @@ tag-images image_name="" default_tag="" tags="":
 
 # DNF CI package cache
 [group('Utility')]
-setup-cache $image="aurora" $ghcr="0" $github_event="0":
+setup-cache $image="aurora" $tag="latest" $ghcr="0" $github_event="0":
     #!/usr/bin/bash
     set -eou pipefail
 
     image_name=$({{ just }} image_name '{{ image }}')
-    fedora_version=$({{ just }} fedora_version '{{ image }}')
+    fedora_version=$({{ just }} fedora_version '{{ image }}' '{{ tag }}')
 
     ALLOW_CACHE_WRITE="false"
 


### PR DESCRIPTION
This always defaulted to latest, which resolves to F43 currently, meaning F44 beta images will never make their own cache otherwise.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
