### PR TITLE
chore: remove mesa-va-drivers from f44

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -33,7 +33,6 @@ OVERRIDES=(
     "mesa-libEGL"
     "mesa-libGL"
     "mesa-libgbm"
-    "mesa-va-drivers"
     "mesa-vulkan-drivers"
 )
 

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -110,7 +110,7 @@ NEGATIVO=(
     libheif
     libva
     mesa-filesystem
-    mesa-va-drivers
+    mesa-dri-drivers
     pipewire-libs-extra
     x264-libs
     x265-libs


### PR DESCRIPTION
https://github.com/negativo17/mesa/commit/cf3cbdcad228f8480b3625648b08ecc79bdcfc4e#diff-3f404ad0d45deaab705a1d68fa56071bb4fc05fde1460b65d4a8ddd37600e011 looks like mesa-dri-drivers obsolete the mesa-va-drivers
