### PR TITLE
fix(beta): add mariadb back

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -224,9 +224,6 @@ EXCLUDED_PACKAGES=(
     khelpcenter
     krfb
     krfb-libs
-    mariadb
-    mariadb-common
-    mariadb-errmsg
     plasma-discover-kns
     plasma-discover-rpm-ostree
     plasma-welcome-fedora


### PR DESCRIPTION
When rebasing from our kinoite base image to aurora:beta the ostree deployment will fail with this error:

```
libsemanage.semanage_direct_get_module_info: Unable to open
mariadb-plugin-cracklib-password-check module lang ext file at
/etc/selinux/targeted/tmp/modules/200/mariadb-plugin-cracklib-password-check/lang_ext.
(No such file or directory).
```

same as https://github.com/ublue-os/aurora/commit/f2ad60cba8752ad0b2ac5330fb90331ee38f7ef7 but this is also needed for f43, this currently prevents a rollback from f44 beta to f43