### PR TITLE
feat(ci): rolling dnf cache

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -98,10 +98,12 @@ jobs:
         env:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
+          MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
           CACHE="$(just setup-cache "${MATRIX_BASE_NAME}" \
                             "${MATRIX_STREAM_NAME}" \
+                            "${MATRIX_IMAGE_FLAVOR}" \
                             "1" \
                             "${GITHUB_EVENT_NAME}")"
 
@@ -117,7 +119,10 @@ jobs:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
         with:
           path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
+          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-
+            ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
 
       - name: Build Image
         id: build-image
@@ -149,7 +154,7 @@ jobs:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
         with:
           path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
+          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
 
       - name: Setup Syft
         id: setup-syft

--- a/Justfile
+++ b/Justfile
@@ -687,11 +687,11 @@ tag-images image_name="" default_tag="" tags="":
 
 # DNF CI package cache
 [group('Utility')]
-setup-cache $image="aurora" $tag="latest" $ghcr="0" $github_event="0":
+setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $github_event="0":
     #!/usr/bin/bash
     set -eou pipefail
 
-    image_name=$({{ just }} image_name '{{ image }}')
+    image_name=$({{ just }} image_name '{{ image }}' '{{ tag }}' '{{ flavor }}')
     fedora_version=$({{ just }} fedora_version '{{ image }}' '{{ tag }}')
 
     ALLOW_CACHE_WRITE="false"


### PR DESCRIPTION
Due to the nature of these caches being immutable (hihi) we can only initially create caches with a certain key and can't update them with fresh packages, this means they would get stale after a certain time. To workaround this we restore from cache x and write and publish to cache y, this has the drawback that this growth will never stop as we don't delete old and unused packages residing inside the cache. This is not a super big issue as the vast majority of packages don't change too often but still an annoyance.

As per the eviction policy [1], caches not accessed for 7 days will be deleted automatically. This should result in a cycle where a scheduled stable (or other manually triggered) workflows will create new cache that will be used by all workflows until the next one is created again.

With this change, manual intervention should never be needed while always having a fresh cache.

This also addresses that the aurora-dx-nvidia-open image got falsely recognized as aurora-dx and attempted to write cache previously.

[1]: https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching#usage-limits-and-eviction-policy

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
