### PR TITLE
chore: don't do zstd:chunked compression for now

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -325,11 +325,11 @@ jobs:
             # TODO: remove me when https://github.com/containers/podman/issues/27796 fixed
 
             for tag in ${ALIAS_TAGS}; do
-              sudo -E /home/linuxbrew/.linuxbrew/bin/podman push --compression-format=zstd:chunked --compression-level=3 ${IMAGE_NAME}:${tag} ${LOWERCASE}/${IMAGE_NAME}:${tag}
+              sudo -E /home/linuxbrew/.linuxbrew/bin/podman push --compression-format=zstd --compression-level=3 ${IMAGE_NAME}:${tag} ${LOWERCASE}/${IMAGE_NAME}:${tag}
             done
 
             for tag in ${ALIAS_TAGS}; do
-              sudo -E /home/linuxbrew/.linuxbrew/bin/podman push --compression-format=zstd:chunked --compression-level=3 ${IMAGE_NAME}:${tag} ${LOWERCASE}/${IMAGE_NAME}:${tag}
+              sudo -E /home/linuxbrew/.linuxbrew/bin/podman push --compression-format=zstd --compression-level=3 ${IMAGE_NAME}:${tag} ${LOWERCASE}/${IMAGE_NAME}:${tag}
             done
 
             digest=$(skopeo inspect docker://${LOWERCASE}/${IMAGE_NAME}:${DEFAULT_TAG} --format '{{.Digest}}')


### PR DESCRIPTION
While it's nice that this doesn't break anything on modern systems, it also has no advantages *for now* as it's just falling back to zstd.

Let's be more careful with this and only do zstd compression for the time being so we don't break older systems that may not have updated to a modern version of rpm-ostree that supports zstd:chunked because they haven't been turned on for quite a while for example.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
