### PR TITLE
feat: add a couple language packs for spectacle OCR

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -134,6 +134,7 @@ FEDORA_PACKAGES=(
     tcpdump
     tesseract-devel
     tmux
+    tesseract-langpack-{deu,fra,spa,por,ita,pol,fin,nld,jpn,hin}
     traceroute
     vim
     yubikey-manager


### PR DESCRIPTION
To avoid us adding *all* 100+ packages to the image (each one is a couple MiB) I only added the most popular languages according to Flathub. See: https://flathub.org/statistics

If one is missing then people can just request it, at least it's getting used then.

Supersedes: https://github.com/ublue-os/aurora/pull/1798

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
