### PR TITLE
feat: add tesseract Chinese variations, Japanese vertical, and English language packs for spectacle OCR

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -134,7 +134,7 @@ FEDORA_PACKAGES=(
     tcpdump
     tesseract-devel
     tmux
-    tesseract-langpack-{deu,fra,spa,por,ita,pol,fin,nld,jpn,hin}
+    tesseract-langpack-{eng,deu,fra,spa,por,ita,pol,fin,nld,jpn,jpn_vert,hin,chi_sim,chi_sim_vert,chi_tra,chi_tra_vert}
     traceroute
     vim
     yubikey-manager


### PR DESCRIPTION
This PR adds Simplified Chinese and Traditional Chinese tesseract langauge packs (both horizontal and vertical), and also Japanese vertical tesseract language pack to the image. Furthermore, it explicitly adds English language tesseract language pack in the list.
