### PR TITLE
chore: remove chinese justfile doc hack

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -12,9 +12,6 @@ dnf versionlock clear
 systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 
-# reinvestigate when https://github.com/ostreedev/ostree/pull/3559 reached fedora
-mv '/usr/share/doc/just/README.中文.md' '/usr/share/doc/just/README.zh-cn.md'
-
 rm -rf /.gitkeep
 
 find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;


### PR DESCRIPTION
New ostree 2026.1 is in fedora 43 and 44, we can finally remove this hack now. This previously made bootc install fail.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
