### PR TITLE
feat(just): add bootc install recipe

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      - name: Debug
+        run: |
+          podman --version
+          df -h
+
       # mount /mnt as /var/lib/containers
       - name: Mount BTRFS for podman storage
         id: container-storage-action
@@ -222,13 +227,39 @@ jobs:
                             "${DEFAULT_TAG}" \
                             "${MATRIX_IMAGE_FLAVOR}"
 
-      - name: Upload OCI dir as Artifact
+      - name: Upload OCI Archive as Artifact
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: ${{ env.IMAGE_NAME }}.oci
           path: ${{ env.IMAGE_NAME }}.oci
           archive: false
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Create Bootable Image
+        # doing other images is not worth it
+        if: github.event_name == 'pull_request' && matrix.base_name == 'aurora' && matrix.image_flavor == 'main'
+        id: bootc-install
+        env:
+          MATRIX_BASE_NAME: ${{ matrix.base_name }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
+          MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
+        run: |
+          sudo -E $(command -v just) disk-image "${MATRIX_BASE_NAME}" \
+                             "${MATRIX_STREAM_NAME}" \
+                             "${MATRIX_IMAGE_FLAVOR}" \
+                             1
+
+      - name: Upload Bootable Image as Artifact
+        if: github.event_name == 'pull_request' && steps.bootc-install.outcome == 'success'
+        id: bootc_install_artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: ${{ env.IMAGE_NAME }}-bootable.img
+          path: bootable.img
+          archive: false
+          compression-level: 9
           if-no-files-found: error
           retention-days: 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,8 @@
-*.iso
-*.iso-CHECKSUM
-flatpaks_with_deps
-flatpak.*
+*.img
 
 aurora*.oci
-previous.manifest.json
+
 changelog.md
 output.env
-version.txt
 
 devcontainer

--- a/Justfile
+++ b/Justfile
@@ -56,8 +56,6 @@ fix:
 clean:
     #!/usr/bin/bash
     set -eoux pipefail
-    touch _build
-    find *_build* -exec rm -rf {} \;
     rm -f changelog.md
     rm -f output.env
 
@@ -636,6 +634,49 @@ setup-cache $image="aurora" $tag="latest" $ghcr="0" $github_event="0":
     CACHE_NAME="${BLESSED_IMAGE}-${fedora_version}"
 
     echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
+
+[group('Utility')]
+[private]
+bootc $image="aurora" $tag="latest" $flavor="main" *ARGS:
+    #!/usr/bin/env bash
+    set -eoux pipefail
+
+    image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
+
+    BOOTC_INSTALL_OPTIONS=()
+    BOOTC_INSTALL_OPTIONS+=("-v" "/var/lib/containers:/var/lib/containers" "-v" "/etc/containers:/etc/containers")
+
+    if [[ -d /sys/fs/selinux ]]; then
+      BOOTC_INSTALL_OPTIONS+=("-v" "/sys/fs/selinux:/sys/fs/selinux" "--security-opt" "label=type:unconfined_t")
+    fi
+
+    podman run \
+        --rm --privileged --pid=host \
+        -it \
+        "${BOOTC_INSTALL_OPTIONS[@]}" \
+        -v /dev:/dev \
+        -v "${BUILD_BASE_DIR:-.}:/data" \
+        localhost/"${image_name}":"${tag}" bootc {{ ARGS }}
+
+# Create bootable image
+[group('Utility')]
+disk-image $image="aurora" $tag="latest" $flavor="main" ghcr="0":
+    #!/usr/bin/env bash
+    set -eoux pipefail
+
+    if [[ "{{ ghcr }}" == "1" ]]; then
+      df -h
+      # aurora-dx is 14.5G
+      SIZE=15G
+    else
+      SIZE=20G
+    fi
+
+    if [ ! -e "${BUILD_BASE_DIR:-.}/bootable.img" ] ; then
+      fallocate -l "${SIZE}" "${BUILD_BASE_DIR:-.}/bootable.img"
+    fi
+
+    {{ just }} bootc "${image}" "${tag}" "${flavor}" install to-disk --generic-image --bootloader grub --via-loopback /data/bootable.img --filesystem btrfs --wipe
 
 # # Examples:
 #   > just retag-nvidia-on-ghcr stable-daily stable-daily-41.20250126.3 0


### PR DESCRIPTION
This makes it easier to test changes that ideally need to be tested on a fresh system. This is basically copy pasted from Zirconium.

I dislike the thing we do to also have compatibility with docker immensely and I want to get rid of it some day but today is not the day :). Keeping this compatibility is in my opinion not worth it because `/var/lib/containers` is podman specific and I want to keep complexity low.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
