### PR TITLE
feat(ci): introduce temporary compatibility tag for f44

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,10 +1,9 @@
 name: Latest Images
 on:
-  merge_group:
+  #merge_group:
   pull_request:
     branches:
-      - main
-      - testing
+      - beta
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"

--- a/Justfile
+++ b/Justfile
@@ -567,6 +567,8 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
         BUILD_TAGS+=("stable" "stable-${version}" "stable-${version:3}")
     elif [[ ! "{{ tag }}" =~ stable|beta ]]; then
         BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${version}" "${FEDORA_VERSION}-${version:3}")
+        # compatiblity for f44, TODO: remove me when we merge beta branch into main
+        BUILD_TAGS+=("beta" "beta-${version}" "beta-${version:3}")
     fi
 
     if [[ "${github_event}" == "pull_request" ]]; then


### PR DESCRIPTION
Instead of having 2 workflows for building beta and latest, which will produce functionally the same image, we have one workflow instead. Latest workflow will tag beta images.

`just generate-build-tags aurora latest`

These are the tags we would be pushing to:
`latest latest-44.20260427 latest-20260427 44 44-44.20260427 44-20260427 beta beta-44.20260427 beta-20260427`

normally this is only `latest latest-44.20260427 latest-20260427 44 44-44.20260427 44-20260427`

We turn the beta workflow off and then we only trigger the latest one, disable merge_group and only make it build on PR against beta branch just like we did with the beta branch

- [x] turn beta workflow off in github ui

needs: https://github.com/ublue-os/aurora/pull/2108