### PR TITLE
feat(ci): turn on f44 builds for latest Part 1

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,10 +1,9 @@
 name: Latest Images
 on:
-  merge_group:
+  #merge_group:
   pull_request:
     branches:
-      - main
-      - testing
+      - beta
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"


### PR DESCRIPTION
This makes it work exactly the way we did the betas

Needed for https://github.com/ublue-os/aurora/pull/2107

- [x] status checks for latest on main branch are turned off