### PR TITLE
feat(ci): turn on renovate for beta branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,6 +4,8 @@
     "config:best-practices"
   ],
 
+  "baseBranchPatterns": ["main", "beta"],
+
   // Do not rebase when the default branch is updated
   "rebaseWhen": "never",
     customManagers: [


### PR DESCRIPTION
Should make it possible to use the image-versions.yaml now for updates instead of manually triggering them.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
