### PR TITLE
chore(ci): enable merge_group for latest

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,6 +1,6 @@
 name: Latest Images
 on:
-  #merge_group:
+  merge_group:
   pull_request:
     branches:
       - beta


### PR DESCRIPTION
We can probably use renovate this way

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
