### PR TITLE
fix(ci): turn off stable builds for merge_queue in beta branch

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -1,6 +1,6 @@
 name: Stable Images
 on:
-  merge_group: # Make Stable-Daily run on merge groups
+  # merge_group: # Make Stable-Daily run on merge groups
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This is broken anyway and isn't supposed to happen.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
