### PR TITLE
chore: bump cosign-installer to v4.1.1

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -337,7 +337,12 @@ jobs:
             echo "digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+        # https://github.com/coreos/rpm-ostree/issues/5509
+        # https://github.com/containers/container-libs/issues/388
+        with:
+          cosign-release: 'v2.6.1'
+
         if: github.event_name != 'pull_request'
 
       - name: Sign container image


### PR DESCRIPTION
This should be safe to do now.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
