### PR TITLE
fix(beta): make sbverify check not fail if missing

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -459,7 +459,7 @@ secureboot $image="aurora" $tag="latest" $flavor="main":
     openssl x509 -in /tmp/akmods.der -out /tmp/akmods.crt
 
     # Make sure we have sbverify
-    CMD="$(command -v sbverify)"
+    CMD="$(command -v sbverify || true)"
     if [[ -z "${CMD:-}" ]]; then
         temp_name="sbverify-${RANDOM}"
         ${PODMAN} run -dt \


### PR DESCRIPTION
I was copying the secureboot recipe of the Justfile to use on my custom image, and noticed that if sbverify isn't present, this line fails due to the `set -e`. It never gets a chance to fall back to the podman method if CMD is empty because of this.
