### PR TITLE
test: remove libzfs

### DIFF
--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -150,7 +150,6 @@ fi
 if [[ ${AKMODS_FLAVOR} =~ coreos ]]; then
   ZFS_PACKAGES=(
       kmod-zfs
-      libzfs6
       zfs
       python3-pyzfs
 )


### PR DESCRIPTION
libzfs7 is now available, I think it's good enough to check for the kmod being there to ensure we actually have ZFS installed.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
