### PR TITLE
fix(ci): push production tags after signing

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -92,6 +92,10 @@ jobs:
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
         if: github.event_name != 'pull_request'
 
+      - name: Install ORAS
+        if: github.event_name != 'pull_request'
+        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
       - name: Check Just Syntax
         shell: bash
         run: |
@@ -312,43 +316,6 @@ jobs:
           echo "${GITHUB_TOKEN}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
           echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
-      # Workaround bugs caused by pushing images but not signing them because of CI flakes
-      - name: Push Ephemeral Tag
-        if: github.event_name != 'pull_request'
-        id: pre-push
-        env:
-          MATRIX_BASE_NAME: "${{ matrix.base_name }}"
-          MATRIX_IMAGE_FLAVOR: "${{ matrix.image_flavor }}"
-          MATRIX_STREAM_NAME: "${{ matrix.stream_name }}"
-          TEMP_PUSH_TAG: "${{ github.run_id }}"
-        run: |
-            set -euox pipefail
-
-            sudo -E $(command -v just) push-image \
-                     "${MATRIX_BASE_NAME}" \
-                     "${MATRIX_STREAM_NAME}" \
-                     "${MATRIX_IMAGE_FLAVOR}" \
-                     "1" \
-                     "${IMAGE_REGISTRY}" \
-                     "1" \
-                     "${TEMP_PUSH_TAG}"
-
-            digest=$(< /tmp/digestfile)
-            echo "digest=${digest}" >> $GITHUB_OUTPUT
-
-      - name: Sign container image
-        if: github.event_name != 'pull_request'
-        env:
-          DIGEST: ${{ steps.pre-push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
-        run: |
-          # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
-          # https://github.com/containers/container-libs/issues/388
-          # https://github.com/coreos/rpm-ostree/issues/5509
-          cosign sign -y --new-bundle-format=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
-
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry
@@ -365,6 +332,8 @@ jobs:
           MATRIX_BASE_NAME: "${{ matrix.base_name }}"
           MATRIX_STREAM_NAME: "${{ matrix.stream_name }}"
           MATRIX_IMAGE_FLAVOR: "${{ matrix.image_flavor }}"
+          GITHUB_REPOSITORY_OWNER: "${{ github.repository_owner }}"
+          COSIGN_PRIVATE_KEY: "${{ secrets.SIGNING_SECRET }}"
         run: |
             set -euox pipefail
 
@@ -373,11 +342,13 @@ jobs:
                      "${MATRIX_STREAM_NAME}" \
                      "${MATRIX_IMAGE_FLAVOR}" \
                      "1" \
-                     "${IMAGE_REGISTRY}"
+                     "${IMAGE_REGISTRY}" \
+                     "${GITHUB_REPOSITORY_OWNER}" \
+                     "1" \
+                     "${COSIGN_PRIVATE_KEY}"
 
-      - name: Install ORAS
-        if: github.event_name != 'pull_request'
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+            digest=$(< /tmp/digestfile)
+            echo "digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Login to GitHub Container Registry with ORAS
         if: github.event_name != 'pull_request'
@@ -392,7 +363,7 @@ jobs:
         id: upload-sbom
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.pre-push.outputs.digest }}
+          DIGEST: ${{ steps.push.outputs.digest }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           SBOM="sbom_out/${IMAGE_NAME}/sbom.json"
@@ -423,7 +394,7 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.pre-push.outputs.digest }}
+          subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
 
   check:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -91,8 +91,6 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
         if: github.event_name != 'pull_request'
-        with:
-          cosign-release: "v2.6.3"
 
       - name: Check Just Syntax
         shell: bash

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -375,11 +375,6 @@ jobs:
                      "1" \
                      "${IMAGE_REGISTRY}"
 
-      # Before push so we don't unnecessarily push when install failed
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
-        if: github.event_name != 'pull_request'
-
       - name: Install ORAS
         if: github.event_name != 'pull_request'
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -87,6 +87,13 @@ jobs:
           /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/resolute buildah/resolute podman/resolute skopeo/resolute just/resolute
           podman --version
 
+      # Before push so we don't unnecessarily push when install failed
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
+        if: github.event_name != 'pull_request'
+        with:
+          cosign-release: "v2.6.3"
+
       - name: Check Just Syntax
         shell: bash
         run: |
@@ -297,13 +304,6 @@ jobs:
           sudo -E $(command -v just) tag-images "${IMAGE_NAME}" \
                           "${DEFAULT_TAG}" \
                           "${ALIAS_TAGS}"
-
-      # Before push so we don't unnecessarily push when install failed
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
-        if: github.event_name != 'pull_request'
-        with:
-          cosign-release: "v2.6.3"
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -302,6 +302,8 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
         if: github.event_name != 'pull_request'
+        with:
+          cosign-release: "v2.6.3"
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -298,6 +298,11 @@ jobs:
                           "${DEFAULT_TAG}" \
                           "${ALIAS_TAGS}"
 
+      # Before push so we don't unnecessarily push when install failed
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
+        if: github.event_name != 'pull_request'
+
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'
         env:
@@ -306,6 +311,43 @@ jobs:
         run: |
           echo "${GITHUB_TOKEN}" | podman login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
           echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      # Workaround bugs caused by pushing images but not signing them because of CI flakes
+      - name: Push Ephemeral Tag
+        if: github.event_name != 'pull_request'
+        id: pre-push
+        env:
+          MATRIX_BASE_NAME: "${{ matrix.base_name }}"
+          MATRIX_IMAGE_FLAVOR: "${{ matrix.image_flavor }}"
+          MATRIX_STREAM_NAME: "${{ matrix.stream_name }}"
+          TEMP_PUSH_TAG: "${{ github.run_id }}"
+        run: |
+            set -euox pipefail
+
+            sudo -E $(command -v just) push-image \
+                     "${MATRIX_BASE_NAME}" \
+                     "${MATRIX_STREAM_NAME}" \
+                     "${MATRIX_IMAGE_FLAVOR}" \
+                     "1" \
+                     "${IMAGE_REGISTRY}" \
+                     "1" \
+                     "${TEMP_PUSH_TAG}"
+
+            digest=$(< /tmp/digestfile)
+            echo "digest=${digest}" >> $GITHUB_OUTPUT
+
+      - name: Sign container image
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.pre-push.outputs.digest }}
+          COSIGN_EXPERIMENTAL: false
+          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+        run: |
+          # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
+          # https://github.com/containers/container-libs/issues/388
+          # https://github.com/coreos/rpm-ostree/issues/5509
+          cosign sign -y --new-bundle-format=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
@@ -319,45 +361,24 @@ jobs:
       - name: Push to GHCR
         id: push
         if: github.event_name != 'pull_request'
-        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         env:
-          ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
-        with:
-          max_attempts: 3
-          retry_wait_seconds: 15
-          timeout_minutes: 10
-          command: |
-            set -euox pipefail
-            # HACK: push a second time so layer annotations are pushed
-            # TODO: remove me when https://github.com/containers/podman/issues/27796 fixed
-
-            for tag in ${ALIAS_TAGS}; do
-              sudo -E podman push --compression-format=zstd --compression-level=3 ${IMAGE_NAME}:${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}:${tag}
-            done
-
-            for tag in ${ALIAS_TAGS}; do
-              sudo -E podman push --compression-format=zstd --compression-level=3 ${IMAGE_NAME}:${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}:${tag}
-            done
-
-            digest=$(skopeo inspect docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG} --format '{{.Digest}}')
-
-            echo "digest=${digest}" >> $GITHUB_OUTPUT
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
-        if: github.event_name != 'pull_request'
-
-      - name: Sign container image
-        if: github.event_name != 'pull_request'
+          MATRIX_BASE_NAME: "${{ matrix.base_name }}"
+          MATRIX_STREAM_NAME: "${{ matrix.stream_name }}"
+          MATRIX_IMAGE_FLAVOR: "${{ matrix.image_flavor }}"
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${TAGS}
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+            set -euox pipefail
+
+            sudo -E $(command -v just) push-image \
+                     "${MATRIX_BASE_NAME}" \
+                     "${MATRIX_STREAM_NAME}" \
+                     "${MATRIX_IMAGE_FLAVOR}" \
+                     "1" \
+                     "${IMAGE_REGISTRY}"
+
+      # Before push so we don't unnecessarily push when install failed
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v4.1.2
+        if: github.event_name != 'pull_request'
 
       - name: Install ORAS
         if: github.event_name != 'pull_request'
@@ -376,7 +397,7 @@ jobs:
         id: upload-sbom
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.pre-push.outputs.digest }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           SBOM="sbom_out/${IMAGE_NAME}/sbom.json"
@@ -407,7 +428,7 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.pre-push.outputs.digest }}
           push-to-registry: true
 
   check:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -395,7 +395,9 @@ jobs:
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
-          push-to-registry: true
+          # this happens to break cosign verify --key statickey.pub
+          # although it does not affect skopeo, podman...
+          push-to-registry: false
 
   check:
     name: Check all ${{ matrix.stream_name }} builds successful

--- a/Justfile
+++ b/Justfile
@@ -720,6 +720,9 @@ push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registr
 
       elif [[ "${temp_push}" == "1" ]]; then
         ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
+        # We need to push twice to workaround https://github.com/containers/podman/issues/27796
+        # If we don't do this then the digest changes and we are only signing this specific tag
+        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
       fi
 
     elif [[ "{{ ghcr }}" == "0" ]]; then

--- a/Justfile
+++ b/Justfile
@@ -690,11 +690,18 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $github_event
 
     echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
 
+# Examples:
+# just push-image aurora latest main 1 ghcr.io/renner0e renner0e 1 "$(cat /path/to/my.key)
+
 # Push Image to Registry
 [group('Utility')]
-push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registry="" $temp_push="0" $temp_push_tag="0":
+push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registry="" $repo_owner="" $sign="0" $cosign_private_key="":
     #!/usr/bin/bash
     set -eoux pipefail
+
+    image_name=$({{ just }} image_name '{{ image }}' '{{ tag }}' '{{ flavor }}')
+
+    alias_tags=$({{ just }} generate-build-tags '{{ image }}' '{{ tag }}' '{{ flavor }}')
 
     PUSH_CMD_ARGS=()
     PUSH_CMD_ARGS+=("--digestfile=/tmp/digestfile")
@@ -703,28 +710,32 @@ push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registr
     PUSH_CMD_ARGS+=("--retry-delay=30s")
     PUSH_CMD_ARGS+=("--retry=5")
 
+    # We don't use cosign to avoid pushing tags to the registry without signatures
+    # in case of signing failures
+    # See: https://github.com/ublue-os/main/issues/643
+    if [[ "{{ sign }}"  == "1" ]]; then
+      PRIVATE_KEY_FILE="$(mktemp)"
+      echo "${cosign_private_key}" > "${PRIVATE_KEY_FILE}"
+      cat ${PRIVATE_KEY_FILE}
+      trap 'rm -f $PRIVATE_KEY_FILE' EXIT
+      REGISTRIES_CONF_DIR="/etc/containers/registries.d"
+      ${SUDOIF} mkdir -p "${REGISTRIES_CONF_DIR}"
+      yq -n '.docker.[env(image_registry)].use-sigstore-attachments = true' | ${SUDOIF} tee "${REGISTRIES_CONF_DIR}/${repo_owner}.yaml"
+
+      SIGN_CMD_ARGS=()
+      SIGN_CMD_ARGS+=("--sign-by-sigstore-private-key=${PRIVATE_KEY_FILE}")
+      SIGN_CMD_ARGS+=("--sign-passphrase-file=/dev/null")
+      PUSH_CMD_ARGS=("${PUSH_CMD_ARGS[@]}" "${SIGN_CMD_ARGS[@]}")
+    fi
+
     PUSH_CMD=""${PODMAN}" push "${PUSH_CMD_ARGS[@]}""
 
-    image_name=$({{ just }} image_name '{{ image }}' '{{ tag }}' '{{ flavor }}')
-
-    alias_tags=$({{ just }} generate-build-tags '{{ image }}' '{{ tag }}' '{{ flavor }}')
-
     if [[ "{{ ghcr }}" == "1" && -n "${image_registry}" ]]; then
-
-      if [[ "${temp_push}" == "0" ]]; then
-        for tag in ${alias_tags}; do
-          ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
-          # We need to push twice to workaround https://github.com/containers/podman/issues/27796
-          ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
-        done
-
-      elif [[ "${temp_push}" == "1" ]]; then
-        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
+      for tag in ${alias_tags}; do
+        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
         # We need to push twice to workaround https://github.com/containers/podman/issues/27796
-        # If we don't do this then the digest changes and we are only signing this specific tag
-        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
-      fi
-
+        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
+      done
     elif [[ "{{ ghcr }}" == "0" ]]; then
       image_registry="ttl.sh"
       dummy_image="docker.io/library/alpine:latest"

--- a/Justfile
+++ b/Justfile
@@ -722,9 +722,10 @@ push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registr
       ${SUDOIF} mkdir -p "${REGISTRIES_CONF_DIR}"
       yq -n '.docker.[env(image_registry)].use-sigstore-attachments = true' | ${SUDOIF} tee "${REGISTRIES_CONF_DIR}/${repo_owner}.yaml"
 
+      PRIVATE_KEY_FILE="$PRIVATE_KEY_FILE" yq -n '.privateKeyFile = env(PRIVATE_KEY_FILE) | .privateKeyPassphraseFile = "/dev/null" | .rekorURL = "https://rekor.sigstore.dev"' | tee sigstore-param-file.yaml
+
       SIGN_CMD_ARGS=()
-      SIGN_CMD_ARGS+=("--sign-by-sigstore-private-key=${PRIVATE_KEY_FILE}")
-      SIGN_CMD_ARGS+=("--sign-passphrase-file=/dev/null")
+      SIGN_CMD_ARGS+=("--sign-by-sigstore=sigstore-param-file.yaml")
       PUSH_CMD_ARGS=("${PUSH_CMD_ARGS[@]}" "${SIGN_CMD_ARGS[@]}")
     fi
 

--- a/Justfile
+++ b/Justfile
@@ -690,6 +690,41 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $github_event
 
     echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
 
+# Push Image to Registry
+[group('Utility')]
+push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registry="" $temp_push="0" $temp_push_tag="0":
+    #!/usr/bin/bash
+    set -eoux pipefail
+
+    PUSH_CMD_ARGS=()
+    PUSH_CMD_ARGS+=("--digestfile=/tmp/digestfile")
+    PUSH_CMD_ARGS+=("--compression-format=zstd")
+    PUSH_CMD_ARGS+=("--compression-level=3")
+    PUSH_CMD_ARGS+=("--retry-delay=30s")
+    PUSH_CMD_ARGS+=("--retry=5")
+
+    PUSH_CMD=""${PODMAN}" push "${PUSH_CMD_ARGS[@]}""
+
+    image_name=$({{ just }} image_name '{{ image }}' '{{ tag }}' '{{ flavor }}')
+
+    alias_tags=$({{ just }} generate-build-tags '{{ image }}' '{{ tag }}' '{{ flavor }}')
+
+    if [[ "{{ ghcr }}" == "1" && -n "${image_registry}" && "${temp_push}" == "0" ]]; then
+      for tag in ${alias_tags}; do
+        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
+        # We need to push twice to workaround https://github.com/containers/podman/issues/27796
+        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
+      done
+    elif [[ "{{ ghcr }}" == "1" && -n "${image_registry}" && "${temp_push}" == "1" ]]; then
+      # Workaround bugs caused by pushing production tags and then signing
+      ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
+    elif [[ "{{ ghcr }}" == "0" ]]; then
+      image_registry="ttl.sh"
+      dummy_image="docker.io/library/alpine:latest"
+
+     ${PUSH_CMD} ${dummy_image} ${image_registry}/${image_name}:${tag}
+    fi
+
 # # Examples:
 #   > just retag-nvidia-on-ghcr stable-daily stable-daily-41.20250126.3 0
 #   > just retag-nvidia-on-ghcr latest latest-41.20250228.1 0

--- a/Justfile
+++ b/Justfile
@@ -709,15 +709,19 @@ push-image $image="aurora" $tag="latest" $flavor="main" $ghcr="0" $image_registr
 
     alias_tags=$({{ just }} generate-build-tags '{{ image }}' '{{ tag }}' '{{ flavor }}')
 
-    if [[ "{{ ghcr }}" == "1" && -n "${image_registry}" && "${temp_push}" == "0" ]]; then
-      for tag in ${alias_tags}; do
-        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
-        # We need to push twice to workaround https://github.com/containers/podman/issues/27796
-        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
-      done
-    elif [[ "{{ ghcr }}" == "1" && -n "${image_registry}" && "${temp_push}" == "1" ]]; then
-      # Workaround bugs caused by pushing production tags and then signing
-      ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
+    if [[ "{{ ghcr }}" == "1" && -n "${image_registry}" ]]; then
+
+      if [[ "${temp_push}" == "0" ]]; then
+        for tag in ${alias_tags}; do
+          ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
+          # We need to push twice to workaround https://github.com/containers/podman/issues/27796
+          ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}
+        done
+
+      elif [[ "${temp_push}" == "1" ]]; then
+        ${PUSH_CMD} ${image_name}:${tag} ${image_registry}/${image_name}:${tag}-${temp_push_tag}
+      fi
+
     elif [[ "{{ ghcr }}" == "0" ]]; then
       image_registry="ttl.sh"
       dummy_image="docker.io/library/alpine:latest"


### PR DESCRIPTION
If the signing step fails, causes for this can be ghcr jank or a
sigstore outage and not testing our changes properly beforehand. Then we
have already pushed images to the registry with production tags that
users can update to.

The clients won't actually update to these images as we enforce
verification on the client side to pull images from ghcr.io/ublue-os/
only with a valid signature attached. Otherwise this leads to an "update
failed" on the users POV, which is very confusing.

To workaround this we push a tag to the registry first that we don't
care about and clients don't check against for updates. I chose the job
id because it always changes.

We used to determine the digest one additional skopeo inspect call, this
should eliminiate a little bit of jank on that side as well as we are
now reading it from a digestfile instead.

This also happens to get rid of the action we use for retries to
workaround ghcr jank, we were forced to do this in the past because the
old podman version we used at the time didn't have those flags.

fixes: https://github.com/ublue-os/aurora/issues/2135

Related: https://github.com/ublue-os/bazzite/pull/4902
Related: https://github.com/ublue-os/main/issues/643
Related: https://github.com/ublue-os/bazzite/issues/3044

Blocked by: https://github.com/ublue-os/aurora/pull/2208, although trivial to fix 

this is more conservative, an alternative approach would be to not use cosign and use podman push instead, which would get rid off some complexity at least.
- https://github.com/zirconium-dev/zirconium/pull/261