### PR TITLE
feat(ci): stop building stable-daily images

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -453,8 +453,6 @@ def generate_changelog(
         curr_pretty = re.sub(r"\.\d{1,2}$", "", curr)
         # Remove target- from curr
         curr_pretty = re.sub(rf"^[a-z]+-|^[0-9]+-", "", curr_pretty)
-        if target == "stable-daily":
-            curr_pretty = re.sub(rf"^[a-z]+-", "", curr_pretty)
         if not fedora_version + "." in curr_pretty:
             curr_pretty=fedora_version + "." + curr_pretty
         pretty = target.capitalize()

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -1,6 +1,5 @@
 name: Stable Images
 on:
-  merge_group: # Make Stable-Daily run on merge groups
   pull_request:
     branches:
       - main

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -52,4 +52,4 @@ jobs:
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:
-      stream_name: '["stable", "stable-daily"]'
+      stream_name: '["stable"]'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -102,17 +102,6 @@ jobs:
           IMAGE_NAME="$(just image_name ${MATRIX_BASE_NAME} ${MATRIX_STREAM_NAME} ${MATRIX_IMAGE_FLAVOR})"
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
 
-      - name: Default Tag
-        shell: bash
-        env:
-          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
-        run: |
-          DEFAULT_TAG="$(just generate-default-tag \
-                       "${MATRIX_STREAM_NAME}" \
-                       "1")"
-          echo "Default Tag: ${DEFAULT_TAG}"
-          echo "DEFAULT_TAG=${DEFAULT_TAG}" >> $GITHUB_ENV
-
       - name: DNF Package Cache Setup
         shell: bash
         id: setup-cache
@@ -205,7 +194,6 @@ jobs:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
           sudo -E $(command -v just) gen-sbom "${MATRIX_BASE_NAME}" \
@@ -218,11 +206,11 @@ jobs:
         shell: bash
         env:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
           sudo -E $(command -v just) secureboot "${MATRIX_BASE_NAME}" \
-                            "${DEFAULT_TAG}" \
+                            "${MATRIX_STREAM_NAME}" \
                             "${MATRIX_IMAGE_FLAVOR}"
 
       - name: Export to OCI Archive
@@ -230,11 +218,11 @@ jobs:
         id: oci-archive
         env:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
           sudo -E $(command -v just) export-oci "${MATRIX_BASE_NAME}" \
-                            "${DEFAULT_TAG}" \
+                            "${MATRIX_STREAM_NAME}" \
                             "${MATRIX_IMAGE_FLAVOR}"
 
       - name: Upload OCI Archive as Artifact
@@ -283,7 +271,6 @@ jobs:
           MATRIX_IMAGE_FLAVOR: "${{ matrix.image_flavor }}"
           INPUTS_KERNEL_PIN: "${{ inputs.kernel_pin }}"
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GITHUB_EVENT_NUMBER: ${{ github.event.number }}
         run: |
@@ -293,7 +280,7 @@ jobs:
                      "${MATRIX_IMAGE_FLAVOR}" \
                      "${INPUTS_KERNEL_PIN}" \
                      "1" \
-                     "$(podman inspect ${IMAGE_NAME}:${DEFAULT_TAG} | jq -r '.[].Config.Labels["org.opencontainers.image.version"]')" \
+                     "$(podman inspect ${IMAGE_NAME}:${MATRIX_STREAM_NAME} | jq -r '.[].Config.Labels["org.opencontainers.image.version"]')" \
                      "${GITHUB_EVENT_NAME}" \
                      "${GITHUB_EVENT_NUMBER}")"
 
@@ -306,12 +293,12 @@ jobs:
         shell: bash
         env:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
         run: |
           set -eoux pipefail
           sudo -E $(command -v just) tag-images "${IMAGE_NAME}" \
-                          "${DEFAULT_TAG}" \
+                          "${MATRIX_STREAM_NAME}" \
                           "${ALIAS_TAGS}"
 
       - name: Login to GitHub Container Registry
@@ -339,7 +326,7 @@ jobs:
         env:
           ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
-          DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
         with:
           max_attempts: 3
           retry_wait_seconds: 15
@@ -357,7 +344,7 @@ jobs:
               sudo -E podman push --compression-format=zstd --compression-level=3 ${IMAGE_NAME}:${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}:${tag}
             done
 
-            digest=$(skopeo inspect docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${DEFAULT_TAG} --format '{{.Digest}}')
+            digest=$(skopeo inspect docker://${IMAGE_REGISTRY}/${IMAGE_NAME}:${MATRIX_STREAM_NAME} --format '{{.Digest}}')
 
             echo "digest=${digest}" >> $GITHUB_OUTPUT
 

--- a/Justfile
+++ b/Justfile
@@ -70,11 +70,6 @@ validate $image $tag $flavor:
     declare -A tags={{ tags }}
     declare -A flavors={{ flavors }}
 
-    # Handle Stable Daily
-    if [[ "${tag}" == "stable-daily" ]]; then
-        tag="stable"
-    fi
-
     checkimage="${images[${image}]-}"
     checktag="${tags[${tag}]-}"
     checkflavor="${flavors[${flavor}]-}"
@@ -119,10 +114,6 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
         akmods_flavor="main"
     fi
 
-    # Fedora Version
-    if [[ {{ ghcr }} == "0" ]]; then
-        rm -f /tmp/manifest.json
-    fi
     fedora_version=$({{ just }} fedora_version '{{ image }}' '{{ tag }}' '{{ flavor }}' '{{ kernel_pin }}')
 
     # Verify Base Image with cosign
@@ -291,7 +282,6 @@ rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previ
     # Image Name
     image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
     fedora_version=$({{ just }} fedora_version '{{ image }}' '{{ tag }}' '{{ flavor }}')
-    DEFAULT_TAG=$({{ just }} generate-default-tag {{ tag }} {{ ghcr }})
 
     if [[ "{{ ghcr }}" == "0" ]]; then
       {{ just }} load-rootful "${image}" "${tag}" "${flavor}"
@@ -300,7 +290,7 @@ rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previ
       # TODO: Redo everything here with --previous-build in rpm-ostree 2026.1+
       # so we don't have to pull an old image + rename it
     if [[ "{{ previous_build }}" == "1" ]]; then
-      PREVIOUS_IMAGE=ghcr.io/{{ repo_organization }}/"${image_name}":"${DEFAULT_TAG}"
+      PREVIOUS_IMAGE=ghcr.io/{{ repo_organization }}/"${image_name}":"${tag}"
 
       # https://github.com/coreos/rpm-ostree/blob/7e2f2065a4aa4d5965b4537bb7d74e0b2898650e/rust/src/compose.rs#L522-L529
       if skopeo inspect docker://"${PREVIOUS_IMAGE}" | jq -e '.LayersData[1:] | all(.Annotations?["ostree.components"]?)'; then
@@ -311,20 +301,19 @@ rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previ
     fi
 
     if [[ "{{ ghcr }}" == "1" ]]; then
-      CHUNKED_IMAGE="localhost/"${image_name}":"${DEFAULT_TAG}""
+      CHUNKED_IMAGE="localhost/"${image_name}":"${tag}""
         if [[ "{{ previous_build }}" == "1" ]]; then
           CHUNKED_IMAGE="${PREVIOUS_IMAGE}"
         fi
     else
       # keep the original unrechunked image for local builds
-      CHUNKED_IMAGE="localhost/"${image_name}":"${DEFAULT_TAG}"-chunked"
+      CHUNKED_IMAGE="localhost/"${image_name}":"${tag}"-chunked"
     fi
 
     # 96 layers, conservative default, same what ci-test is using
     # one layer is secretly being added for the ostree export
     # 499 is podman run limit
     # 128 is docker pull limit
-    # in CI this renames stable to stable-daily
     ${SUDOIF} ${PODMAN} run --rm \
         --pull=${PULL_POLICY} \
         --privileged \
@@ -340,7 +329,7 @@ rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previ
 
         # rename the image to localhost
         if [[ "{{ ghcr }}" == "1" && "{{ previous_build }}" == "1" ]]; then
-          ${SUDOIF} ${PODMAN} tag ${CHUNKED_IMAGE} "localhost/"${image_name}":"${DEFAULT_TAG}""
+          ${SUDOIF} ${PODMAN} tag ${CHUNKED_IMAGE} "localhost/"${image_name}":"${tag}""
           ${SUDOIF} ${PODMAN} image rm -f ${CHUNKED_IMAGE}
         fi
 
@@ -358,18 +347,16 @@ chunkah $image="aurora" $tag="latest" $flavor="main" ghcr="0":
     {{ just }} validate {{ image }} {{ tag }} {{ flavor }}
 
     image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
-    DEFAULT_TAG=$({{ just }} generate-default-tag {{ tag }} {{ ghcr }})
 
-    export CHUNKAH_CONFIG_STR=$(${PODMAN} inspect "${image_name}:${DEFAULT_TAG}")
-    ${PODMAN} run --rm --mount=type=image,src="${image_name}:${DEFAULT_TAG}",target=/chunkah \
-    -e RUST_LOG=debug \
+    export CHUNKAH_CONFIG_STR=$(${PODMAN} inspect "${image_name}:${tag}")
+    ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \
     -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah:dev \
     build \
     --compressed \
     --max-layers 128 \
     --prune /sysroot/ \
     --label ostree.commit- --label ostree.final-diffid- \
-    --tag "${image_name}:${DEFAULT_TAG}" | ${PODMAN} load
+    --tag "${image_name}:${tag}" | ${PODMAN} load
 
 # For Rechunk
 [group('Image')]
@@ -550,15 +537,9 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
     #!/usr/bin/bash
     set -eou pipefail
 
-    TODAY="$(date +%A)"
-    WEEKLY="Tuesday"
-    if [[ {{ ghcr }} == "0" ]]; then
-        rm -f /tmp/manifest.json
-    fi
     FEDORA_VERSION="$({{ just }} fedora_version '{{ image }}' '{{ tag }}' '{{ flavor }}' '{{ kernel_pin }}')"
-    DEFAULT_TAG=$({{ just }} generate-default-tag {{ tag }} {{ ghcr }})
     IMAGE_NAME=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
-    # Use Build Version from Rechunk
+
     if [[ -z "${version:-}" ]]; then
         version="{{ tag }}-${FEDORA_VERSION}.$(date +%Y%m%d)"
     fi
@@ -576,24 +557,24 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
         COMMIT_TAGS+=(${SHA_SHORT}-{{ tag }}-${version})
     fi
 
-    # Convenience Tags
-    if [[ "{{ tag }}" =~ stable ]]; then
-        BUILD_TAGS+=("stable-daily" "${version}" "stable-daily-${version}" "stable-daily-${version:3}")
-    else
-        BUILD_TAGS+=("{{ tag }}" "{{ tag }}-${version}" "{{ tag }}-${version:3}")
+    # These are always used regardless of the stream
+    COMMON_TAGS=()
+    COMMON_TAGS+=("{{ tag }}" "{{ tag }}-${version}" "{{ tag }}-${version:3}")
+    BUILD_TAGS=("${COMMON_TAGS[@]}" "${BUILD_TAGS[@]}")
+
+    if [[ "{{ tag }}" == stable ]]; then
+      # Legacy Compatibility Tag so stable-daily points to stable, do not remove this
+      # TODO: Move this to :latest after the ZFS removal to get daily updates again
+      BUILD_TAGS+=("{{ tag }}-daily" "${version}" "{{ tag }}-daily-${version}" "{{ tag }}-daily-${version:3}")
+
+    elif [[ "{{ tag }}" == latest ]]; then
+      # We only want :$FEDORA_VERSION to point to :latest
+      BUILD_TAGS+=("{{ tag }}-${FEDORA_VERSION}" "${FEDORA_VERSION}-${version}" "${FEDORA_VERSION}-${version:3}")
+
+      # No special handling here for testing for now
     fi
 
-    # Weekly Stable / Rebuild Stable on workflow_dispatch
     github_event="{{ github_event }}"
-    if [[ "{{ tag }}" =~ "stable" && "${WEEKLY}" == "${TODAY}" && "${github_event}" =~ schedule ]]; then
-        BUILD_TAGS+=("stable" "stable-${version}" "stable-${version:3}")
-    elif [[ "{{ tag }}" =~ "stable" && "${github_event}" =~ workflow_dispatch|workflow_call ]]; then
-        BUILD_TAGS+=("stable" "stable-${version}" "stable-${version:3}")
-    elif [[ "{{ tag }}" =~ "stable" && "{{ ghcr }}" == "0" ]]; then
-        BUILD_TAGS+=("stable" "stable-${version}" "stable-${version:3}")
-    elif [[ ! "{{ tag }}" =~ stable|beta ]]; then
-        BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${version}" "${FEDORA_VERSION}-${version:3}")
-    fi
 
     if [[ "${github_event}" == "pull_request" ]]; then
         alias_tags=("${COMMIT_TAGS[@]}")
@@ -602,23 +583,6 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
     fi
 
     echo "${alias_tags[*]}"
-
-# Generate Default Tag
-[group('Utility')]
-generate-default-tag tag="latest" ghcr="0":
-    #!/usr/bin/bash
-    set -eou pipefail
-
-    # Default Tag
-    if [[ "{{ tag }}" =~ stable && "{{ ghcr }}" == "1" ]]; then
-        DEFAULT_TAG="stable-daily"
-    elif [[ "{{ tag }}" =~ stable && "{{ ghcr }}" == "0" ]]; then
-        DEFAULT_TAG="stable"
-    else
-        DEFAULT_TAG="{{ tag }}"
-    fi
-
-    echo "${DEFAULT_TAG}"
 
 # Tag Images
 [group('Utility')]
@@ -742,11 +706,11 @@ disk-image $image="aurora" $tag="latest" $flavor="main" ghcr="0" $bootc_fs="btrf
     {{ just }} bootc "${image}" "${tag}" "${flavor}" install to-disk --generic-image --bootloader grub --via-loopback /data/bootable.img --filesystem "${bootc_fs}" --wipe
 
 # # Examples:
-#   > just retag-nvidia-on-ghcr stable-daily stable-daily-41.20250126.3 0
+#   > just retag-nvidia-on-ghcr stable stable-41.20250126.3 0
 #   > just retag-nvidia-on-ghcr latest latest-41.20250228.1 0
 #
-# working_tag: The tag of the most recent known good image (e.g., stable-daily-41.20250126.3)
-# stream:      One of latest, stable-daily, stable or gts
+# working_tag: The tag of the most recent known good image (e.g., latest.20250126.3)
+# stream:      One of latest, stable or testing
 # dry_run:     Only print the skopeo commands instead of running them
 #
 # First generate a PAT with package write access (https://github.com/settings/tokens)


### PR DESCRIPTION
These do not make super much sense, this is in preparation for the testing branches so we don't build too many images.

We will still build stable images in PRs to find out if things are broken on those images only.

To not break existing users, point this to `:stable` instead, effectively lying about the cadence now. We have to do it this way because stable-daily has ZFS and `:latest` doesn't to avoid breaking that use case. In the future when we have removed ZFS we can point this to `:latest`.

this makes this much easier to implement:
- https://github.com/ublue-os/aurora/issues/1833

- [ ] remove tag from rebase-helper (https://github.com/get-aurora-dev/common/pull/177)
- [ ] handle kcm_ublue (https://github.com/ledif/kcm_ublue/issues/22)
- [ ] reflect this change in the docs (https://github.com/ublue-os/aurora-docs/pull/373)
- [ ] make a systemd service to rebase people from :stable-daily to :stable (kinda overkill and optional, compatibility tag we will have to keep forever anyway )
- [ ] make a blog post about the change

anything else we should be doing?