### PR TITLE
fix(ci): don't pull down a previous image on PRs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -184,7 +184,7 @@ jobs:
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
           DEFAULT_TAG: ${{ env.DEFAULT_TAG }}
-          PREVIOUS_BUILD: ${{ github.event.inputs.previous_build || '1' }}
+          PREVIOUS_BUILD: ${{ github.event_name == 'pull_request' && '0' || (github.event.inputs.previous_build || '1') }}
         run: |
           sudo -E $(command -v just) rechunk "${MATRIX_BASE_NAME}" \
                             "${MATRIX_STREAM_NAME}" \


### PR DESCRIPTION
Kinda unnecessary to do this, kinda expensive operation for the time being as it's an image pull, in the future this will be easier or we are gonna use chunkah anyway.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
