### PR TITLE
fix(swtpm-workaround): order after rechunker-group-fix.service

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/swtpm-workaround.service.d/10-order-after-rechunker-group-fix.conf
+++ b/system_files/shared/usr/lib/systemd/system/swtpm-workaround.service.d/10-order-after-rechunker-group-fix.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=rechunker-group-fix.service


### PR DESCRIPTION
## Problem

On Aurora-DX, VMs started with a vTPM after boot fail with:

```
swtpm died and reported: libvirt: error : cannot execute binary /usr/bin/swtpm: Permission denied
```

Tracked as #2152 (Aurora) and ublue-os/bluefin#4538 (Bluefin, byte-identical `swtpm-workaround.service` from `get-aurora-dev/common`). Only Aurora hits the boot-time failure.

## Root cause

`rechunker-group-fix.service` (Aurora-only) ends `ExecStart` with:

```
ExecStart=systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
```

`systemd-tmpfiles --create` re-applies ownership, mode, and the path-based default SELinux context on every invocation. The `C`-rule in `/usr/lib/tmpfiles.d/swtpm-workaround.conf`:

```
C /usr/local/bin/overrides/swtpm - - - - /usr/bin/swtpm
```

`-` means default context. `matchpathcon /var/usrlocal/bin/overrides/swtpm` → `bin_t` (no `swtpm_exec_t` fcontext rule for `/var/usrlocal/...`). Every `systemd-tmpfiles --create` pass relabels the override back to `bin_t`; the bind mount propagates that to `/usr/bin/swtpm`.

Both units only depend on `local-fs.target`, so they start in parallel. When `rechunker-group-fix.service` finishes after `swtpm-workaround.service`, the relabel is clobbered.

Post-boot reproduction:

```
$ sudo systemctl restart swtpm-workaround.service
$ ls -lZ /usr/local/bin/overrides/swtpm
... system_u:object_r:swtpm_exec_t:s0 ... swtpm

$ sudo systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
$ ls -lZ /usr/local/bin/overrides/swtpm
... system_u:object_r:bin_t:s0 ... swtpm
```

## Fix

Drop-in ordering `swtpm-workaround.service` after `rechunker-group-fix.service`. Placed in this repo rather than `get-aurora-dev/common` because the race is Aurora-only — Bluefin and other downstreams that consume `common` don't have this conflict.

## Verification

`aurora-dx:latest-44.20260516.1`, before and after:

- Without drop-in: both units finish around the same time at boot; `/usr/bin/swtpm` ends up `bin_t`; vTPM VMs fail.
- With drop-in: `rechunker-group-fix.service` finishes first, `swtpm-workaround.service` runs after, `/usr/bin/swtpm` stays `swtpm_exec_t`; AVC gone.

`systemd-analyze verify swtpm-workaround.service` clean.

Refs ublue-os/aurora#2152, ublue-os/bluefin#4538.