### PR TITLE
feat(packages): Add gcc-c++ to packages so Homebrew has a c++

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -60,7 +60,7 @@ FEDORA_PACKAGES=(
     fish
     flatpak-spawn
     foo2zjs
-    gcc
+    gcc{,-c++}
     git-credential-libsecret
     glow
     google-noto-sans-balinese-fonts


### PR DESCRIPTION
Homebrew assumes that the OS provides a `c++` executable.

See discussions on Bluefin [1] and Homebrew [2] forums.

[1]: ublue-os#4585 (comment)
[2]: https://github.com/orgs/Homebrew/discussions/6832#discussioncomment-16827154

(cherry picked from https://github.com/ublue-os/bluefin/commit/685c1e1a961c1212ea54f80e69bf4f5f56f95652)

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
