### PR TITLE
chore: move to stable Sunshine package

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -148,7 +148,7 @@ copr_install_isolated "ledif/kairpods" \
     "kairpods"
 
 # Sunshine from lizardbyte/beta COPR
-copr_install_isolated "lizardbyte/beta" \
+copr_install_isolated "lizardbyte/stable" \
     "sunshine"
 
 # Packages to exclude - common to all versions

--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -147,7 +147,7 @@ copr_install_isolated "ublue-os/packages" \
 copr_install_isolated "ledif/kairpods" \
     "kairpods"
 
-# Sunshine from lizardbyte/beta COPR
+# Sunshine from lizardbyte/stable COPR
 copr_install_isolated "lizardbyte/stable" \
     "sunshine"
 


### PR DESCRIPTION
Maybe we could also just move recommending the flatpak. It was also updated and looking at few comments, looks like it might actually just work.
