### PR TITLE
feat: remove patched fwupd

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -180,14 +180,6 @@ if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     fi
 fi
 
-# https://github.com/ublue-os/bazzite/issues/1400
-# TODO: test if we still need this when upgrading firmware with fwupd
-dnf -y copr enable ublue-os/staging
-dnf -y copr disable ublue-os/staging
-dnf -y swap \
-  --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
-  fwupd fwupd
-
 ## Pins and Overrides
 ## Use this section to pin packages in order to avoid regressions
 # Remember to leave a note with rationale/link to issue for each pin!
@@ -199,6 +191,8 @@ dnf -y swap \
 #fi
 
 # https://invent.kde.org/plasma/plasma-setup/-/issues/72
+dnf -y copr enable ublue-os/staging
+dnf -y copr disable ublue-os/staging
 dnf -y swap --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
   plasma-setup plasma-setup-"${PLASMA_VERS}"-*.aurora
 


### PR DESCRIPTION
There have been quite a couple changes in the last couple years that were bootloader related in Fedora, namely switching to bootupd [1] with F41 which allows updating the bootloader. Maybe this happenend to resolve the issue because it got changed to fedora at some point?

Originally needed because fwupd looks for EFI/our_ID/**.

The only change we make to our package is hardcoding efi_os_dir=fedora with a build option.

New installs have the directory set to fedora.

Introduced in 78671f2.

~~I have no idea if we still need this, this is a scream test.~~

[1]: https://fedoraproject.org/wiki/Changes/FedoraSilverblueBootupd

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
