### PR TITLE
feat(ci): preparation for ARM builds

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -41,6 +41,10 @@ jobs:
       stream_name: latest
       #kernel_pin: 6.12.15-200.fc41.x86_64
       previous_build: ${{ inputs.previous_build }}
+      # FIXME: MAIN has no arm builds in ublue-os/akmods yet
+      # https://github.com/ublue-os/akmods/pull/440
+      # architecture: '["aarch64","x86_64"]'
+      architecture: '["x86_64"]'
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -43,6 +43,9 @@ jobs:
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
       previous_build: ${{ inputs.previous_build }}
+      # Enable ARM when it makes sense
+      # architecture: '["aarch64","x86_64"]'
+      architecture: '["x86_64"]'
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -21,6 +21,11 @@ on:
       previous_build:
         description: 'Set a reference to a previous build to make updates smaller'
         type: string
+      architecture:
+        description: "JSON string of architectures to build, '[aarch64, x86_64]'"
+        default: "['x86_64']"
+        required: false
+        type: string
 
 env:
   IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
@@ -34,7 +39,7 @@ permissions: {}
 jobs:
   build_container:
     name: image
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.architecture == 'x86_64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions:
       contents: read
       packages: write
@@ -49,6 +54,11 @@ jobs:
         image_flavor: ${{ fromJson(inputs.image_flavors) }}
         base_name: ["${{ inputs.brand_name }}", "${{ inputs.brand_name }}-dx"]
         stream_name: ["${{ inputs.stream_name }}"]
+        architecture: ${{ fromJson(inputs.architecture) }}
+        exclude:
+          # DX is "legacy", don't build them for arm
+          - architecture: aarch64
+            base_name: "${{ inputs.brand_name }}-dx"
 
     steps:
       - name: Checkout
@@ -140,10 +150,10 @@ jobs:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
         with:
           path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
+          key: ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-
-            ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
+            ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-
+            ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}
 
       - name: Build Image
         id: build-image
@@ -175,7 +185,7 @@ jobs:
           CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
         with:
           path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
+          key: ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
 
       - name: Rechunk Image with rpm-ostree
         id: rechunker
@@ -241,8 +251,8 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: ${{ env.IMAGE_NAME }}.oci
-          path: ${{ env.IMAGE_NAME }}.oci
+          name: ${{ env.IMAGE_NAME }}-${{ matrix.architecture }}.oci
+          path: ${{ env.IMAGE_NAME }}-${{ matrix.architecture }}.oci
           archive: false
           if-no-files-found: error
           retention-days: 1

--- a/Justfile
+++ b/Justfile
@@ -403,7 +403,9 @@ export-oci $image="aurora" $tag="latest" $flavor="main":
     # Image Name
     image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
 
-    ${PODMAN} push --compression-format=zstd --compression-level=3 localhost/"${image_name}":"${tag}" oci-archive:"${image_name}".oci
+    ARCHIVE_NAME="${image_name}"-"$(arch)".oci
+
+    ${PODMAN} push --compression-format=zstd --compression-level=3 localhost/"${image_name}":"${tag}" oci-archive:"${ARCHIVE_NAME}"
 
 # Run Container
 [group('Image')]

--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -99,7 +99,6 @@ FEDORA_PACKAGES=(
     pamu2fcfg
     plasma-wallpapers-dynamic
     plasma-firewall-"${PLASMA_VERS}"
-    powerstat
     powertop
     rclone
     restic
@@ -118,18 +117,29 @@ FEDORA_PACKAGES=(
     zsh
 )
 
+FEDORA_PACKAGES_AMD64=(
+    powerstat
+  )
+
 NEGATIVO_PACKAGES=(
     ffmpeg{,-libs}
-    intel-vaapi-driver
     libfdk-aac
     libva-utils
     pipewire-libs-extra
     uld
   )
 
-# Install all Fedora packages (bulk - safe from COPR injection)
-echo "Installing ${#FEDORA_PACKAGES[@]} packages from Fedora repos and ${#NEGATIVO_PACKAGES[@]} from Negativo..."
-dnf5 -y install "${FEDORA_PACKAGES[@]}" "${NEGATIVO_PACKAGES[@]}"
+NEGATIVO_PACKAGES_AMD64=(
+    intel-vaapi-driver
+  )
+
+PACKAGES=( "${FEDORA_PACKAGES[@]}" "${NEGATIVO_PACKAGES[@]}" )
+
+if [[ $(arch) == x86_64 ]]; then
+  PACKAGES+=( "${FEDORA_PACKAGES_AMD64[@]}" "${NEGATIVO_PACKAGES_AMD64[@]}" )
+fi
+
+dnf -y install "${PACKAGES[@]}"
 
 # Fedora Tailscale is usually behind
 dnf config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo


### PR DESCRIPTION
ARM builds generally need a lot of work, so I'm splitting this up into a few PRs.

This doesn't actually build more images, we can just enable them when we made progress on [1].

[1]: https://github.com/ublue-os/aurora/issues/2274

turning them on makes them build successfully
https://github.com/renner0e/aurora/actions/runs/26666019490/job/78599431260?pr=37
