### PR TITLE
feat(ci): add index point for multiple daily builds

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -59,6 +59,7 @@ clean:
     rm -f changelog.md
     rm -f output.env
     rm -rf sbom_out
+    rm -f /tmp/aurora*-tags.json
 
 # Check if valid combo
 [group('Utility')]
@@ -143,22 +144,15 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     {{ just }} verify-container cosign.pub "ghcr.io/ublue-os/brew:latest@${brew_image_sha}"
 
     # Get Version
+    TIMESTAMP="$(date +%Y%m%d)"
     if [[ "${tag}" =~ stable ]]; then
-        ver="${fedora_version}.$(date +%Y%m%d)"
+        ver="${fedora_version}.${TIMESTAMP}"
     else
-        ver="${tag}-${fedora_version}.$(date +%Y%m%d)"
+        ver="${tag}-${fedora_version}.${TIMESTAMP}"
     fi
-    skopeo list-tags docker://ghcr.io/{{ repo_organization }}/${image_name} > /tmp/repotags.json
-    if [[ $(jq "any(.Tags[]; contains(\"$ver\"))" < /tmp/repotags.json) == "true" ]]; then
-        POINT="1"
-        while $(jq -e "any(.Tags[]; contains(\"$ver.$POINT\"))" < /tmp/repotags.json)
-        do
-            (( POINT++ ))
-        done
-    fi
-    if [[ -n "${POINT:-}" ]]; then
-        ver="${ver}.$POINT"
-    fi
+
+    POINT=$({{ just }} generate-point {{ image }} {{ tag }} {{ flavor }})
+    ver="${ver}.$POINT"
 
     # Build Arguments
     BUILD_ARGS=()
@@ -542,12 +536,12 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
     FEDORA_VERSION="$({{ just }} fedora_version '{{ image }}' '{{ tag }}' '{{ flavor }}' '{{ kernel_pin }}')"
     IMAGE_NAME=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
 
+    TIMESTAMP="$(date +%Y%m%d)"
     if [[ -z "${version:-}" ]]; then
-        version="{{ tag }}-${FEDORA_VERSION}.$(date +%Y%m%d)"
+        version="{{ tag }}-${FEDORA_VERSION}.${TIMESTAMP}"
     fi
     version=${version#{{ tag }}-}
 
-    # Arrays for Tags
     BUILD_TAGS=()
     COMMIT_TAGS=()
 
@@ -559,21 +553,35 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
         COMMIT_TAGS+=(${SHA_SHORT}-{{ tag }}-${version})
     fi
 
+    POINT=$({{ just }} generate-point {{ image }} {{ tag }} {{ flavor }})
+
     # These are always used regardless of the stream
     COMMON_TAGS=()
-    COMMON_TAGS+=("{{ tag }}" "{{ tag }}-${version}" "{{ tag }}-${version:3}")
+    COMMON_TAGS+=("{{ tag }}")
+    COMMON_TAGS+=("{{ tag }}-${version}")
+    COMMON_TAGS+=("{{ tag }}-${version:3}")
+    COMMON_TAGS+=("{{ tag }}-${version}.${POINT}")
+    COMMON_TAGS+=("{{ tag }}-${version:3}.${POINT}")
+
     BUILD_TAGS=("${COMMON_TAGS[@]}" "${BUILD_TAGS[@]}")
 
+    # No special handling here for testing for now
     if [[ "{{ tag }}" == stable ]]; then
       # Legacy Compatibility Tag so stable-daily points to stable, do not remove this
       # TODO: Move this to :latest after the ZFS removal to get daily updates again
-      BUILD_TAGS+=("{{ tag }}-daily" "${version}" "{{ tag }}-daily-${version}" "{{ tag }}-daily-${version:3}")
-
+      BUILD_TAGS+=("{{ tag }}-daily")
+      BUILD_TAGS+=("${version}")
+      BUILD_TAGS+=("{{ tag }}-daily-${version}")
+      BUILD_TAGS+=("{{ tag }}-daily-${version:3}")
+      BUILD_TAGS+=("{{ tag }}-daily-${version}.${POINT}")
+      BUILD_TAGS+=("{{ tag }}-daily-${version:3}.${POINT}")
     elif [[ "{{ tag }}" == latest ]]; then
       # We only want :$FEDORA_VERSION to point to :latest
-      BUILD_TAGS+=("{{ tag }}-${FEDORA_VERSION}" "${FEDORA_VERSION}-${version}" "${FEDORA_VERSION}-${version:3}")
-
-      # No special handling here for testing for now
+      BUILD_TAGS+=("{{ tag }}-${FEDORA_VERSION}")
+      BUILD_TAGS+=("${FEDORA_VERSION}-${version}")
+      BUILD_TAGS+=("${FEDORA_VERSION}-${version:3}")
+      BUILD_TAGS+=("${FEDORA_VERSION}-${version}.${POINT}")
+      BUILD_TAGS+=("${FEDORA_VERSION}-${version:3}.${POINT}")
     fi
 
     github_event="{{ github_event }}"
@@ -585,6 +593,38 @@ generate-build-tags image="aurora" tag="latest" flavor="main" kernel_pin="" ghcr
     fi
 
     echo "${alias_tags[*]}"
+
+# Get Index Point for multiple daily images
+[private]
+generate-point image="aurora" tag="latest" flavor="main":
+    #!/usr/bin/bash
+    set -eoux pipefail
+
+    IMAGE_NAME=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
+    TIMESTAMP="$(date +%Y%m%d)"
+
+    tags="/tmp/${IMAGE_NAME}-tags.json"
+
+    if [[ ! -f ${tags} ]]; then
+      skopeo list-tags docker://ghcr.io/{{ repo_organization }}/${IMAGE_NAME} > "${tags}"
+    fi
+
+    if [[ $(jq --arg tag "{{ tag }}" --arg timestamp "${TIMESTAMP}" 'any(.Tags[]; contains($tag + "-" + $timestamp))' < "${tags}") == "true" ]]; then
+
+      # our image already exists, so find the highest POINT
+      POINT=$(jq -r --arg tag "{{ tag }}" --arg timestamp "${TIMESTAMP}" \
+        '($tag + "-" + $timestamp) as $base | [ .Tags[] | select(startswith($base + ".")) ] | sort_by(split(".")[-1]
+        | tonumber)
+        |.[-1] | if . == null then "1" else split(".")[-1] end' < "${tags}")
+
+      ((POINT++))
+
+    else
+      # there is no image that exists for that day yet
+      POINT=1
+    fi
+
+    echo "${POINT}"
 
 # Tag Images
 [group('Utility')]


### PR DESCRIPTION
Currently we are tagging these:

```
latest
latest-44.20260531
latest-20260531
latest-44
44-44.20260531
44-20260531
```

and this PR will add:

```
latest-44.20260531.2
latest-20260531.2
44-44.20260531.2
44-20260531.2
```

and for stable:

```
stable
stable-44.20260531
stable-20260531
stable-daily
44.20260531
stable-daily-44.20260531
stable-daily-20260531
```

```
stable-44.20260531.1
stable-20260531.1
stable-daily-44.20260531.1
stable-daily-20260531.1
```

Today there has been no stable image released so it starts out with .1
but there has been a single latest image, so it bumps it to .2

Very much inspired by ublue-os/main's solution [1], but this
implementation has a bug where where it will find the first "missing"
POINT (not the highest!) in the tags.

This would falsely choose the wrong POINT in the case we delete a bad
image and there is a "gap".

For example, we have the images .1-3 already on the registry, then
delete .2 and this implementation would correctly choose the next image
as .4 (instead of .2) as it's not just a dumb while loop.

This is very much an edge case and makes the jq command quite cursed but
I think this should always be reliable.

This feature has been broken previously because we didn't tag the image
with an index point number so no matter how many images we have built
that day, it was always .1 in the various VESRION fields in os-release.

fixes: https://github.com/ublue-os/aurora/issues/1833

[1]: https://github.com/ublue-os/main/blob/ef33e7ca96d797702cc137b6eefc8a08ed50d068/Justfile#L239-L251