### PR TITLE
fix: add cjk-vf font package back

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -171,7 +171,6 @@ EXCLUDED_PACKAGES=(
     ffmpegthumbnailer
     firefox
     firewall-config
-    google-noto-sans-cjk-vf-fonts
     kcharselect
     khelpcenter
     krfb{,-libs}


### PR DESCRIPTION
This causes certain characters to not be displayed properly, on my
system this was the case for system applications like dolphin and
konsole as well as flatpak applications like firefox and discord.

for example: 처형박수

This was originally introduced in [1] because of [2].

I'm not 100% sure if this doesn't break something else, but I tested
this by setting Steam (Flatpak) to chinese and I didn't see any
misrendered characters like described in [3]. It seems like this got
resolved at some point by something(?)

[1]: https://github.com/ublue-os/main/pull/334
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=2188765
[3]: https://github.com/ValveSoftware/steam-for-linux/issues/9418

CC: https://github.com/ublue-os/bluefin/pull/475

Bazzite also suffers from this issue

See: https://github.com/ublue-os/main/blob/ef33e7ca96d797702cc137b6eefc8a08ed50d068/packages.json#L89