### PR TITLE
fix(ci): switch back to just from homebrew

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -77,7 +77,7 @@ jobs:
       # TODO: remove me when we have a new podman in 26.04 runners
       # needed because old podman doesn't push layer annotations for
       # the rpm-ostree rechunker at all
-      - name: Update podman and install just
+      - name: Update podman
         shell: bash
         run: |
           set -eux
@@ -94,8 +94,13 @@ jobs:
           echo "deb ${mirror} resolute universe main" | sudo tee /etc/apt/sources.list.d/resolute.list
           /bin/time -f '%E %C' sudo apt update
           # skopeo is currently older in resolute for some reason hence --allow-downgrades
-          /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/resolute buildah/resolute podman/resolute skopeo/resolute just/resolute
+          /bin/time -f '%E %C' sudo apt install -y --allow-downgrades crun/resolute buildah/resolute podman/resolute skopeo/resolute
           podman --version
+
+      - name: Install Just
+        run: |
+          /home/linuxbrew/.linuxbrew/bin/brew install just
+          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
 
       # FIXME: Implement retries for stuff like this
       - name: Install Cosign
@@ -109,6 +114,7 @@ jobs:
       - name: Check Just Syntax
         shell: bash
         run: |
+          just --version
           just check
 
       - name: Image Name

--- a/Justfile
+++ b/Justfile
@@ -1,24 +1,30 @@
 export repo_organization := env("GITHUB_REPOSITORY_OWNER", "ublue-os")
 export base_image_org := env("BASE_IMAGE_ORG", "quay.io/fedora-ostree-desktops")
 export base_image_name := env("BASE_IMAGE_NAME", "kinoite")
+
 export common_image := env("COMMON_IMAGE", "ghcr.io/get-aurora-dev/common:latest")
 export brew_image := env("BREW_IMAGE", "ghcr.io/ublue-os/brew:latest")
+
 stable_version := "44"
 latest_version := "44"
 testing_version := "44"
+
 images := '(
     [aurora]=aurora
     [aurora-dx]=aurora-dx
 )'
+
 flavors := '(
     [main]=main
     [nvidia-open]=nvidia-open
 )'
+
 tags := '(
     [stable]=stable
     [latest]=latest
     [testing]=testing
 )'
+
 export SUDO_DISPLAY := if `if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then echo true; fi` == "true" { "true" } else { "false" }
 export SUDOIF := if `id -u` == "0" { "" } else { "sudo" }
 export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
@@ -34,22 +40,22 @@ default:
 check:
     #!/usr/bin/bash
     find . -type f -name "*.just" | while read -r file; do
-    	echo "Checking syntax: $file"
-    	{{ just }} --unstable --fmt --check -f $file
+      echo "Checking syntax: $file"
+      {{ just }} --fmt --check -f $file
     done
     echo "Checking syntax: Justfile"
-    {{ just }} --unstable --fmt --check -f Justfile
+    {{ just }} --fmt --check -f Justfile
 
 # Fix Just Syntax
 [group('Just')]
 fix:
     #!/usr/bin/bash
     find . -type f -name "*.just" | while read -r file; do
-    	echo "Checking syntax: $file"
-    	{{ just }} --unstable --fmt -f $file
+      echo "Checking syntax: $file"
+      {{ just }} --fmt -f $file
     done
     echo "Checking syntax: Justfile"
-    {{ just }} --unstable --fmt -f Justfile || { exit 1; }
+    {{ just }} --fmt -f Justfile || { exit 1; }
 
 # Clean Repo
 [group('Utility')]


### PR DESCRIPTION
The ubuntu 26.04 provided version is still too old, recently they stabilized the --fmt flag [1]. This is consistent with the other invokations and also allows us to have some whitespace between variable definitions for example as they seemed to have changed that.

[1]: https://github.com/casey/just/commit/21b3833bf0cb07238d8a7647bae6e87612f22590

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
