### PR TITLE
chore: recommend rpm-ostree status instead of bootc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -26,8 +26,8 @@ body:
   - type: textarea
     id: version
     attributes:
-      label: Output of `bootc status`
-      description: Please run `sudo bootc status` and paste the output here, it is the only way we can verify the exact image you are on for debugging purposes.
+      label: Output of `rpm-ostree status`
+      description: Please run `rpm-ostree status` and paste the output here, it is the only way we can verify the exact image you are on for debugging purposes.
       render: shell
   - type: textarea
     id: groups


### PR DESCRIPTION
While bootc is the thing we should be using for this longterm, this information is often times completely useless due to it not including a date and the image name when people have layered packages.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
