### PR TITLE
feat: swap podman-bootc for bcvk

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -18,6 +18,7 @@ source /ctx/build_files/shared/copr-helpers.sh
 FEDORA_PACKAGES=(
     android-tools
     bcc
+    bcvk
     bpftop
     bpftrace
     cockpit-bridge
@@ -99,7 +100,6 @@ dnf -y install --enablerepo=code \
 echo "Installing DX COPR packages with isolated repo enablement..."
 
 copr_install_isolated "karmab/kcli" "kcli"
-copr_install_isolated "gmaglione/podman-bootc" "podman-bootc"
 copr_install_isolated "ublue-os/packages" "ublue-os-libvirt-workarounds"
 
 # DX packages to exclude - common to all versions

--- a/build_files/dx/10-tests-dx.sh
+++ b/build_files/dx/10-tests-dx.sh
@@ -12,7 +12,6 @@ IMPORTANT_PACKAGES_DX=(
     docker-compose-plugin
     flatpak-builder
     libvirt
-    podman-bootc
     qemu
 )
 


### PR DESCRIPTION
We should probably have done this a while ago.

See https://github.com/bootc-dev/podman-bootc/pull/134 for more details.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
