### PR TITLE
fix(ci): switch over to unwanted-software action again

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -64,15 +64,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      # mount /mnt as /var/lib/containers
-      - name: Mount BTRFS for podman storage
-        id: container-storage-action
-        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
-        continue-on-error: true
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
-          loopback-free: '1'
+      - name: Free Up Space
+        id: remove-unwanted-software
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
 
       # TODO: remove me when we have a new podman in 26.04 runners
       # needed because old podman doesn't push layer annotations for


### PR DESCRIPTION
This takes 1min to run but is more reliable than the container-storage-action in some cases on runners with only 20GB of available disk space on /. We correctly mount /mnt to /var/lib/containers via the container-storage-action when we have low space available but we are running out space on /var/tmp, which this action does not address, this usually happens on the COMMIT step of the image build.

Observed here: [1]

[1]:
https://github.com/ublue-os/aurora/actions/runs/26897102965/job/79339038302

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
