### PR TITLE
chore(ci): make latest images build after push

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - stable-f44
+    paths-ignore:
+      - "**.md"
+      - ".github/workflows/moderator.yml"
+      - ".github/workflows/scorecard.yml"
   merge_group:
     branches:
       - stable-f44

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,5 +1,8 @@
 name: Latest Images
 on:
+  push:
+    branches:
+      - stable-f44
   merge_group:
     branches:
       - stable-f44


### PR DESCRIPTION
Seems the latest images don't build when something gets merged to `stable-f44` branch as it should.

We don't use merge group in that branch so we are missing the `push`  action from the workflow

or are we missing something else?