### PR TITLE
feat(ci): use chunkah for rechunking

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -19,14 +19,6 @@ on:
       - ".github/workflows/scorecard.yml"
   workflow_call:
   workflow_dispatch:
-    inputs:
-      previous_build:
-        description: 'Set to 0 to manually clear rechunking plan'
-        type: choice
-        default: '1'
-        options:
-          - '0'
-          - '1'
 
 permissions:
   contents: read
@@ -49,7 +41,6 @@ jobs:
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
       #kernel_pin: 6.12.15-200.fc41.x86_64
-      previous_build: ${{ inputs.previous_build }}
       # FIXME: MAIN has no arm builds in ublue-os/akmods yet
       # https://github.com/ublue-os/akmods/pull/440
       # architecture: '["aarch64","x86_64"]'

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -13,14 +13,6 @@ on:
       - ".github/workflows/scorecard.yml"
   workflow_call:
   workflow_dispatch:
-    inputs:
-      previous_build:
-        description: 'Set to 0 to manually clear rechunking plan'
-        type: choice
-        default: '1'
-        options:
-          - '0'
-          - '1'
 
 permissions:
   contents: read
@@ -42,7 +34,6 @@ jobs:
       #kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
-      previous_build: ${{ inputs.previous_build }}
       # Enable ARM when it makes sense
       # architecture: '["aarch64","x86_64"]'
       architecture: '["x86_64"]'

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -10,14 +10,6 @@ on:
        - ".github/workflows/scorecard.yml"
    workflow_call:
    workflow_dispatch:
-    inputs:
-      previous_build:
-        description: 'Set to 0 to manually clear rechunking plan'
-        type: choice
-        default: '1'
-        options:
-          - '0'
-          - '1'
 
 permissions:
   contents: read
@@ -39,7 +31,7 @@ jobs:
       image_flavors: '["main", "nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: testing
-      previous_build: ${{ inputs.previous_build }}
+      #kernel_pin: 6.12.15-200.fc41.x86_64
       # FIXME: MAIN has no arm builds in ublue-os/akmods yet
       # https://github.com/ublue-os/akmods/pull/440
       # architecture: '["aarch64","x86_64"]'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -18,9 +18,6 @@ on:
       kernel_pin:
         description: "The full kernel version to pin"
         type: string
-      previous_build:
-        description: 'Set a reference to a previous build to make updates smaller'
-        type: string
       architecture:
         description: "JSON string of architectures to build, '[aarch64, x86_64]'"
         default: "['x86_64']"
@@ -190,20 +187,16 @@ jobs:
           path: /var/tmp/buildah-cache-*
           key: ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
 
-      - name: Rechunk Image with rpm-ostree
+      - name: Rechunk Image with Chunkah
         id: rechunker
         env:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
-          PREVIOUS_BUILD: ${{ github.event_name == 'pull_request' && '0' || (github.event.inputs.previous_build || '1') }}
         run: |
           sudo -E $(command -v just) rechunk "${MATRIX_BASE_NAME}" \
                             "${MATRIX_STREAM_NAME}" \
-                            "${MATRIX_IMAGE_FLAVOR}" \
-                            "1" \
-                            "0" \
-                            "${PREVIOUS_BUILD}"
+                            "${MATRIX_IMAGE_FLAVOR}"
 
       - name: Setup Syft
         id: setup-syft

--- a/Justfile
+++ b/Justfile
@@ -25,6 +25,9 @@ tags := '(
     [testing]=testing
 )'
 
+# Build Containers
+chunkah := shell("yq -r \".images[] | select(.name == \\\"chunkah\\\") | \\\"\\\\(.image)@\\\\(.digest)\\\"\" image-versions.yml")
+
 export SUDO_DISPLAY := if `if [ -n "${DISPLAY:-}" ] || [ -n "${WAYLAND_DISPLAY:-}" ]; then echo true; fi` == "true" { "true" } else { "false" }
 export SUDOIF := if `id -u` == "0" { "" } else { "sudo" }
 export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
@@ -146,6 +149,11 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
       --certificate-oidc-issuer https://token.actions.githubusercontent.com \
       --certificate-identity-regexp="github.com/get-aurora-dev/common/.github/workflows/*" \
       "ghcr.io/get-aurora-dev/common:latest@${common_image_sha}"
+
+    cosign verify \
+      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+      --certificate-identity-regexp="github.com/coreos/chunkah/.github/workflows/*" \
+      "{{ chunkah }}"
 
     {{ just }} verify-container cosign.pub "ghcr.io/ublue-os/brew:latest@${brew_image_sha}"
 
@@ -278,9 +286,31 @@ build-pipeline image="aurora" tag="latest" flavor="main" kernel_pin="":
 
 # Rechunk Image
 [group('Image')]
-rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previous_build="0":
+rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
     #!/usr/bin/bash
 
+    {{ just }} validate {{ image }} {{ tag }} {{ flavor }}
+
+    image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
+
+    export CHUNKAH_CONFIG_STR=$(${PODMAN} inspect "${image_name}:${tag}")
+
+    set -eoux pipefail
+
+    ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \
+    -e CHUNKAH_CONFIG_STR "{{ chunkah }}" \
+    build \
+    --verbose \
+    --compressed \
+    --max-layers 128 \
+    --prune /sysroot/ \
+    --label ostree.commit- --label ostree.final-diffid- \
+    --tag "${image_name}:${tag}" | ${PODMAN} load
+
+# build-chunked-oci
+[group('Image')]
+ostree-rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previous_build="0":
+    #!/usr/bin/bash
     set -eoux pipefail
 
     # Validate
@@ -345,27 +375,7 @@ rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0" previ
         sudo -u "${SUDO_USER}" {{ just }} secureboot "${image}" "${tag}" "${flavor}"
     fi
 
-# Rechunk Image but cooler
-[group('Image')]
-chunkah $image="aurora" $tag="latest" $flavor="main" ghcr="0":
-    #!/usr/bin/bash
-    set -oeux pipefail
-
-    {{ just }} validate {{ image }} {{ tag }} {{ flavor }}
-
-    image_name=$({{ just }} image_name {{ image }} {{ tag }} {{ flavor }})
-
-    export CHUNKAH_CONFIG_STR=$(${PODMAN} inspect "${image_name}:${tag}")
-    ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \
-    -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah:dev \
-    build \
-    --compressed \
-    --max-layers 128 \
-    --prune /sysroot/ \
-    --label ostree.commit- --label ostree.final-diffid- \
-    --tag "${image_name}:${tag}" | ${PODMAN} load
-
-# For Rechunk
+# For Privileged operations
 [group('Image')]
 load-rootful $image="aurora" $tag="latest" $flavor="main":
     #!/usr/bin/bash
@@ -740,10 +750,11 @@ disk-image $image="aurora" $tag="latest" $flavor="main" ghcr="0" $bootc_fs="btrf
 
     # this is enough for base aurora to make it more likely to run in CI
     if [[ "{{ ghcr }}" == "1" ]]; then
-      IMG_SIZE=11G
+      # absurd size so it will always be enough for the image
+      IMG_SIZE=35G
     else
-      # Do a little more locally so you can rebase
-      IMG_SIZE=30G
+      # Should at least be enough to rebase and install couple applications
+      IMG_SIZE=40G
     fi
 
     BYTES_IMAGE_SIZE=$(numfmt --from=iec ${IMG_SIZE})

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,13 +1,24 @@
 images:
+  # https://gitlab.com/fedora/ostree/ci-test
   - name: kinoite
     image: quay.io/fedora-ostree-desktops/kinoite
     tag: 44
     digest: sha256:4e181985b0478335500896816be8cd1c19fa77d5d9888e7b04838b3c195bb01c
+
+  # https://github.com/get-aurora-dev/common
   - name: common
     image: ghcr.io/get-aurora-dev/common
     tag: latest
     digest: sha256:60b8b391d0cee44228d41e1ab17507e02e9e1396de9487065f524b2ea7314734
+
+  # https://github.com/ublue-os/brew/
   - name: brew
     image: ghcr.io/ublue-os/brew
     tag: latest
     digest: sha256:fc3d3c27060e4bbbcb2e21a17a50c083b2588d404097ac86c97b1b2a75576db1
+
+  # https://github.com/coreos/chunkah
+  - name: chunkah
+    image: quay.io/coreos/chunkah
+    tag: latest
+    digest: sha256:ff8b8b466a942ec6000445d4001fc661e2fc5a952ad9ee29b4de9ab09d1d1708


### PR DESCRIPTION
Chunkah is actively maintained and the algorithm seems to be more stable
for the layer plan which results in smaller sizes for weekly updates
compared to rpm-ostree. Although it looks like daily updates are
slightly bigger for the time being.

In the future there may be a way to consume previous build manifests as
well to further shrink down image sizes.

I am not deleting the old build-chunked-oci yet, to make this PR easier
to revert in case we have to.

Rpm-ostree is basically the only blocker for rootless CI, which is
generally what we should be doing, PolP and all that. Now we only need
root privileges for bootc install. Althought to keep this PR more simple
I will implement this later.

It seems like bootc install needs more space now, not sure exactly why
that happens but seems to be related due to pruned /sysroot.

xref https://github.com/ublue-os/aurora/issues/2324