### PR TITLE
chore(ci): use ubuntu-slim for check jobs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -449,7 +449,7 @@ jobs:
   check:
     name: Check all ${{ matrix.stream_name }} builds successful
     if: always()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: [build_container]
     steps:
       - name: Check Jobs


### PR DESCRIPTION
We are just running a couple lines of bash here.

See: https://github.com/ublue-os/aurora/issues/1728

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
