### PR TITLE
fix: build-chunked-oci --from image name

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -360,7 +360,7 @@ ostree-rechunk $image="aurora" $tag="latest" $flavor="main" ghcr="0" pipeline="0
         --max-layers 127 \
         --format-version=2 \
         --bootc \
-        --from "${image_name}:${tag}" \
+        --from "localhost/${image_name}:${tag}" \
         --output containers-storage:${CHUNKED_IMAGE}
 
         # rename the image to localhost


### PR DESCRIPTION
fixup of d029a023. rpm-ostree needs the full reference.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
