### PR TITLE
feat(ci): add more aggressive retries for pulling

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -243,6 +243,9 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
 
     PODMAN_BUILD_ARGS=("${BUILD_ARGS[@]}" "${LABELS[@]}" --tag "${image_name}:${tag}" --file Containerfile.in)
 
+    # Bump retries to minimize network flakes
+    PODMAN_BUILD_ARGS+=("--retry=5" "--retry-delay=60s")
+
     # Add GitHub token secret if available (for CI/CD)
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then
         echo "Adding GitHub token as build secret"


### PR DESCRIPTION
This should minimize the network flakes we run into when we have to pull images as part of the many `FROM`s, the default is 3 tries with 2s delay, which is really low.

I'm not 100% sure it will help us, let's just try it!

See: https://github.com/ublue-os/aurora/issues/2337

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
