### PR TITLE
feat(ci): increase dnf timeout to combat network flakes

### DIFF
--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -4,8 +4,9 @@ set -eoux pipefail
 
 echo "::group:: Copy Files"
 
-# Speeds up local builds
-dnf config-manager setopt keepcache=1
+# Speeds up local builds and workaround network flakes, mainly for COPR and negativo
+cp /etc/dnf/dnf.conf /etc/dnf/dnf.conf.bak
+dnf config-manager setopt keepcache=1 timeout=60
 
 # We need to remove this package here because lots of files we add from `{projectbluefin,get-aurora-dev}/common` override the rpm files
 # they go away when you do dnf remove

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -5,7 +5,7 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # Revert back to upstream defaults
-dnf config-manager setopt keepcache=0
+mv /etc/dnf/dnf.conf.bak /etc/dnf/dnf.conf
 dnf versionlock clear
 
 # This comes last because we can't *ever* afford to ship fedora flatpaks on the image


### PR DESCRIPTION
The default is 30s, let's see if this is already enough. Most packages should usually be cached, it's the retrieval of metadata that is often the reason for the network related flakes.

xref: https://github.com/ublue-os/aurora/issues/2337

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
