### PR TITLE
fix(ci): properly retry registry logins

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -851,7 +851,7 @@ login-registry bin="" registry="":
 
     {{ retry_function }}
 
-    echo "${GITHUB_TOKEN}" | retry 5 60 "{{ bin }}" login "{{ registry }}" -u "${GITHUB_ACTOR}" --password-stdin
+    retry 5 60 echo "${GITHUB_TOKEN}" | "{{ bin }}" login "{{ registry }}" -u "${GITHUB_ACTOR}" --password-stdin
 
 # # Examples:
 #   > just retag-nvidia-on-ghcr stable stable-41.20250126.3 0


### PR DESCRIPTION
This is the right way to do this, credentials would be missing if we do run into the case where we have to retry the login.

xref: https://github.com/ublue-os/aurora/issues/2337

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
