### PR TITLE
chore(ci): set pull=newer for build command

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -202,12 +202,6 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
     fi
     BUILD_ARGS+=("--build-arg" "UBLUE_IMAGE_TAG=${tag}")
 
-    # Pull in most recent upstream base image
-    # if building locally/not ghcr pull the new image
-    if [[ {{ ghcr }} == "0" ]]; then
-        ${PODMAN} pull "${base_image_org}/${base_image_name}:${fedora_version}"
-    fi
-
     # Labels
     LABELS=()
     LABELS+=("--label" "containers.bootc=1")
@@ -245,6 +239,11 @@ build $image="aurora" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipeline
 
     # Bump retries to minimize network flakes
     PODMAN_BUILD_ARGS+=("--retry=5" "--retry-delay=60s")
+
+    # So we always have the newest images when building locally
+    if [[ {{ ghcr }} == "0" ]]; then
+      PODMAN_BUILD_ARGS+=("--pull=newer")
+    fi
 
     # Add GitHub token secret if available (for CI/CD)
     if [[ -n "${GITHUB_TOKEN:-}" ]]; then


### PR DESCRIPTION
This is probably the way we should be doing it instead of having a separate pull, also works for the other images, mainly useful for akmods and kinoite as we do not pin those by a digest. Which we should be doing at some point.

In the future we probably want to have some kind of mechanism that ensures that we are only pulling the blessed verified image (configuring the runner environment with a policy).

Currently we are verifying the tag and then pulling the image a short while later. This is not very likely to happen but leaves a couple seconds of room where an untrusted image could be published that we did not verify the authenticity of.

This ties a little bit into [1].

[1]: https://github.com/ublue-os/aurora/issues/2381

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
