### PR TITLE
feat(ci): package cache with OCI artifacts

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -24,3 +24,11 @@ jobs:
           delete-orphaned-images: true
           keep-n-tagged: 7
           keep-n-untagged: 7
+
+      - name: Delete All OCI Artifact Cache
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f # v1.2.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: aurora/cache/dnf
+          keep-n-tagged: 1
+          older-than: 90 days

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -308,9 +308,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          $(command -v just) login-registry podman ghcr.io
+          just login-registry podman ghcr.io
           # cosign gets credentials from docker
-          $(command -v just) login-registry docker ghcr.io
+          just login-registry docker ghcr.io
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
@@ -362,7 +362,7 @@ jobs:
           # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
           # https://github.com/containers/container-libs/issues/388
           # https://github.com/coreos/rpm-ostree/issues/5509
-          $(which cosign) sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
+          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
 
       - name: Push to GHCR
         id: push
@@ -395,7 +395,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          $(command -v just) login-registry oras ghcr.io
+          just login-registry oras ghcr.io
 
       - name: Upload SBOM
         if: inputs.publish
@@ -426,7 +426,7 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
-          $(command -v cosign) sign -y --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${SBOM_DIGEST}
+          cosign sign -y --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${SBOM_DIGEST}
 
       - name: Attestation
         if: inputs.publish

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -115,8 +115,12 @@ jobs:
         if: inputs.publish
 
       - name: Install ORAS
-        if: inputs.publish
         uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
+
+      # actions put things in a weird unpredictable path
+      - name: Make ORAS accessible for root/sudo
+        run: |
+          sudo mv $(which oras) /usr/local/bin
 
       - name: Check Just Syntax
         shell: bash
@@ -138,38 +142,23 @@ jobs:
 
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
 
-      - name: DNF Package Cache Setup
+      - name: DNF Package Cache Pull
         shell: bash
-        id: setup-cache
+        id: pull-cache
         env:
           MATRIX_BASE_NAME: ${{ matrix.base_name }}
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
         run: |
-          CACHE="$(just setup-cache \
-                --image "${MATRIX_BASE_NAME}" \
-                --tag "${MATRIX_STREAM_NAME}" \
-                --flavor "${MATRIX_IMAGE_FLAVOR}" \
-                --ghcr \
-                --github-event "${GITHUB_EVENT_NAME}")"
-
-          CACHE_NAME="$(echo "${CACHE}" | cut -d' ' -f 1)"
-          ALLOW_CACHE_WRITE="$(echo "${CACHE}" | cut -d' ' -f 2)"
-
-          echo "cache_name=${CACHE_NAME}" >> "$GITHUB_OUTPUT"
-          echo "allow_cache_write=${ALLOW_CACHE_WRITE}" >> "$GITHUB_OUTPUT"
-
-      - name: Restore DNF package cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        env:
-          CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
-        with:
-          path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
-          restore-keys: |
-            ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-
-            ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}
+          sudo -E $(command -v just) \
+            setup-cache \
+            --image "${MATRIX_BASE_NAME}" \
+            --tag "${MATRIX_STREAM_NAME}" \
+            --flavor "${MATRIX_IMAGE_FLAVOR}" \
+            --ghcr \
+            --registry "${IMAGE_REGISTRY}" \
+            --pull
 
       - name: Build Image
         id: build-image
@@ -188,21 +177,26 @@ jobs:
             --flavor "${MATRIX_IMAGE_FLAVOR}" \
             --ghcr
 
-      # https://github.com/actions/cache/issues/1533
-      - name: Hack around permission issue caching
-        shell: bash
-        id: cache-perms
-        run: |
-          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
-
       - name: Write new DNF package cache
-        if: steps.setup-cache.outputs.allow_cache_write == 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: push-cache
+        shell: bash
+        if: inputs.publish
         env:
-          CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
-        with:
-          path: /var/tmp/buildah-cache-*
-          key: ${{ runner.os }}-${{ matrix.architecture }}-buildah-${{ env.CACHE_NAME }}-${{ github.run_id }}
+          MATRIX_BASE_NAME: ${{ matrix.base_name }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
+          MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sudo -E $(command -v just) \
+            setup-cache \
+            --image "${MATRIX_BASE_NAME}" \
+            --tag "${MATRIX_STREAM_NAME}" \
+            --flavor "${MATRIX_IMAGE_FLAVOR}" \
+            --ghcr \
+            --registry "${IMAGE_REGISTRY}" \
+            --github-event "${GITHUB_EVENT_NAME}" \
+            --push
 
       - name: Rechunk Image with Chunkah
         id: rechunker
@@ -343,9 +337,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          just login-registry podman ghcr.io
+          sudo -E $(command -v just) login-registry podman ghcr.io
           # cosign gets credentials from docker
-          just login-registry docker ghcr.io
+          sudo -E $(command -v just) login-registry docker ghcr.io
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
@@ -397,7 +391,7 @@ jobs:
           # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
           # https://github.com/containers/container-libs/issues/388
           # https://github.com/coreos/rpm-ostree/issues/5509
-          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
+          sudo -E $(which cosign) sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
 
       - name: Push to GHCR
         id: push
@@ -430,7 +424,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
         run: |
-          just login-registry oras ghcr.io
+          sudo -E $(command -v just) login-registry oras ghcr.io
 
       - name: Upload SBOM
         if: inputs.publish
@@ -443,13 +437,13 @@ jobs:
           SBOM="sbom_out/${IMAGE_NAME}/sbom.json"
 
           cd "$(dirname "${SBOM}")"
-          oras attach \
+          sudo -E oras attach \
           --artifact-type application/vnd.spdx+json \
           --annotation filename=$(basename "$SBOM") \
           "${IMAGE}@${DIGEST}" \
           "$(basename ${SBOM})"
 
-          sbom_digest=$(oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[] | select(.artifactType == "application/vnd.spdx+json") | .digest')
+          sbom_digest=$(sudo -E oras discover --format json "${IMAGE}@${DIGEST}" | jq -r '.referrers[] | select(.artifactType == "application/vnd.spdx+json") | .digest')
 
           echo "sbom_digest=${sbom_digest}" >> $GITHUB_OUTPUT
 
@@ -461,7 +455,7 @@ jobs:
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
           SBOM_DIGEST: ${{ steps.upload-sbom.outputs.sbom_digest }}
         run: |
-          cosign sign -y --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${SBOM_DIGEST}
+          sudo -E $(command -v cosign) sign -y --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${SBOM_DIGEST}
 
       - name: Attestation
         if: inputs.publish

--- a/Justfile
+++ b/Justfile
@@ -743,15 +743,22 @@ gen-sbom $image="aurora" $tag="latest" $flavor="main" $syft_cmd="syft":
 
     rm -rf "${ROOTFS}"
 
+# We are not using https://github.com/actions/cache because of:
+# https://github.com/ublue-os/aurora/issues/2351
+# https://github.com/actions/cache/issues/1537
+
 # DNF CI package cache
 [arg("flavor", long="flavor", short="f")]
 [arg("ghcr", long="ghcr", value="true")]
 [arg("github_event", long="github-event")]
 [arg("image", long="image", short="i")]
+[arg("pull", long="pull", value="true")]
+[arg("push", long="push", value="true")]
+[arg("registry", long="registry")]
 [arg("tag", long="tag", short="t")]
 [group('Utility')]
 [private]
-setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $github_event="":
+setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $pull="false" $push="false" $registry="" $github_event="":
     #!/usr/bin/env bash
     set -eou pipefail
 
@@ -759,19 +766,39 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $github_e
 
     fedora_version=$({{ just }} fedora_version --image "${image}" --tag "${tag}" --flavor "${flavor}")
 
-    ALLOW_CACHE_WRITE="false"
-
+    # compromise between most shared packages
     BLESSED_IMAGE=aurora-dx
 
-    if [[ "${image_name}" == "${BLESSED_IMAGE}" ]] && \
-       [[ "${ghcr}" == "true" ]] && \
-       [[ "${github_event}" == "workflow_dispatch" || "${github_event}" == "schedule" ]]; then
-        ALLOW_CACHE_WRITE="true"
+    CACHE_NAME="aurora/cache/dnf"
+    CACHE_IMAGE="${registry}/${CACHE_NAME}:${fedora_version}-$(arch)"
+
+    # directory where buildah-cache-UID is
+    BUILDAH_CACHE_DIR="/var/tmp"
+    BUILDAH_CACHE="buildah-cache-${UID}"
+
+    POINT=$({{ just }} generate-point --image "${image}" --tag "${tag}" --flavor "${flavor}")
+    CURRENT_DAY="$(LC_TIME=C date +%A)"
+
+    if [[ "${CURRENT_DAY}" == "Sunday" && "$POINT" == "1" && "${ghcr}" == "true" ]]; then
+      echo "Not pulling build cache. Uploading fresh cache later."
+    elif [[ "${pull}" == "true" ]]; then
+      # We want to avoid using --allow-path-traversal
+      pushd "${BUILDAH_CACHE_DIR}"
+      oras pull "${CACHE_IMAGE}" || exit 0
+      popd
     fi
 
-    CACHE_NAME="${BLESSED_IMAGE}-${fedora_version}"
+    if [[ "${image_name}" == "${BLESSED_IMAGE}" ]] && \
+       [[ "${pull:-false}" == "false" ]] && \
+       [[ "${push}" == "true" ]] && \
+       [[ "${ghcr}" == "true" ]] && \
+       [[ "${github_event}" == "workflow_dispatch" || "${CURRENT_DAY}" == "Sunday" && "${POINT}" == "1" ]]; then
 
-    echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
+      {{ just }} login-registry oras ghcr.io
+      pushd "${BUILDAH_CACHE_DIR}"
+      oras push "${CACHE_IMAGE}" "${BUILDAH_CACHE}"
+      popd
+    fi
 
 [arg("flavor", long="flavor", short="f")]
 [arg("image", long="image", short="i")]

--- a/Justfile
+++ b/Justfile
@@ -778,8 +778,9 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $pull="fa
 
     POINT=$({{ just }} generate-point --image "${image}" --tag "${tag}" --flavor "${flavor}")
     CURRENT_DAY="$(LC_TIME=C date +%A)"
+    BLESSED_DAY="Sunday"
 
-    if [[ "${CURRENT_DAY}" == "Sunday" && "$POINT" == "1" && "${ghcr}" == "true" ]]; then
+    if [[ "${CURRENT_DAY}" == "${BLESSED_DAY}" && "$POINT" == "1" && "${ghcr}" == "true" ]]; then
       echo "Not pulling build cache. Uploading fresh cache later."
     elif [[ "${pull}" == "true" ]]; then
       # We want to avoid using --allow-path-traversal
@@ -792,7 +793,7 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $pull="fa
        [[ "${pull:-false}" == "false" ]] && \
        [[ "${push}" == "true" ]] && \
        [[ "${ghcr}" == "true" ]] && \
-       [[ "${github_event}" == "workflow_dispatch" || "${CURRENT_DAY}" == "Sunday" && "${POINT}" == "1" ]]; then
+       [[ "${github_event}" == "workflow_dispatch" || "${CURRENT_DAY}" == "${BLESSED_DAY}" && "${POINT}" == "1" ]]; then
 
       {{ just }} login-registry oras ghcr.io
       pushd "${BUILDAH_CACHE_DIR}"


### PR DESCRIPTION
We are hitting a couple limitations in regards to actions/cache [1] with our new testing branch workflow, as we previously relied on scheduled builds from the main branch, which we no longer do with this model.

Now we make new cache on merge_group on the first build on Sundays, I chose Sundays just because. Which means we run only a single build with no cache per week and use that same build to generate a new fresh cache.

Else we would end up with 3 versions of vscode in our cache. There is no point uploading cache on *every* PR.

For simplicity sake this has no handling/differentiation for our stable and main branch. When we bump the fedora version of our main/testing images then the cache for stable will just get stale.

We are mixing root/rootless usage of oras/cosign, I made it use root or else we will get premission issues.

[1]: https://github.com/actions/cache/issues/1537

fixes: https://github.com/ublue-os/aurora/issues/2351

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
