### PR TITLE
feat(ci): rootless CI

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -157,7 +157,7 @@ jobs:
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
-          sudo -E $(command -v just) \
+          $(command -v just) \
             repo_organization="${{ github.repository_owner }}" \
             build \
             --image "${MATRIX_BASE_NAME}" \
@@ -170,7 +170,7 @@ jobs:
         shell: bash
         id: cache-perms
         run: |
-          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
+          chmod 777 --recursive /var/tmp/buildah-cache-${UID}
 
       - name: Write new DNF package cache
         if: steps.setup-cache.outputs.allow_cache_write == 'true'
@@ -188,7 +188,7 @@ jobs:
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
-          sudo -E $(command -v just) rechunk \
+         $(command -v just) rechunk \
             --image "${MATRIX_BASE_NAME}" \
             --tag "${MATRIX_STREAM_NAME}" \
             --flavor "${MATRIX_IMAGE_FLAVOR}"
@@ -207,7 +207,7 @@ jobs:
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
         run: |
-          sudo -E $(command -v just) gen-sbom \
+          $(command -v just) gen-sbom \
             --image "${MATRIX_BASE_NAME}" \
             --tag "${MATRIX_STREAM_NAME}" \
             --flavor "${MATRIX_IMAGE_FLAVOR}" \
@@ -221,7 +221,7 @@ jobs:
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
-          sudo -E $(command -v just) secureboot \
+         $(command -v just) secureboot \
             --image "${MATRIX_BASE_NAME}" \
             --tag "${MATRIX_STREAM_NAME}" \
             --flavor "${MATRIX_IMAGE_FLAVOR}"
@@ -234,7 +234,7 @@ jobs:
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
-          sudo -E $(command -v just) export-oci \
+          $(command -v just) export-oci \
             --image "${MATRIX_BASE_NAME}" \
             --tag "${MATRIX_STREAM_NAME}" \
             --flavor "${MATRIX_IMAGE_FLAVOR}"
@@ -260,7 +260,7 @@ jobs:
           MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
           MATRIX_IMAGE_FLAVOR: ${{ matrix.image_flavor }}
         run: |
-          sudo -E $(command -v just) disk-image \
+          $(command -v just) disk-image \
           --image "${MATRIX_BASE_NAME}" \
           --tag "${MATRIX_STREAM_NAME}" \
           --flavor "${MATRIX_IMAGE_FLAVOR}" \
@@ -309,7 +309,7 @@ jobs:
           ALIAS_TAGS: ${{ steps.generate-tags.outputs.alias_tags }}
         run: |
           set -eoux pipefail
-          sudo -E $(command -v just) tag-images \
+          $(command -v just) tag-images \
             --image "${IMAGE_NAME}" \
             --default-tag "${MATRIX_STREAM_NAME}" \
             --tags "${ALIAS_TAGS}"
@@ -346,7 +346,7 @@ jobs:
         run: |
             set -euox pipefail
 
-            sudo -E $(command -v just) push-image \
+            $(command -v just) push-image \
               --image "${MATRIX_BASE_NAME}" \
               --tag "${MATRIX_STREAM_NAME}" \
               --flavor "${MATRIX_IMAGE_FLAVOR}" \
@@ -386,7 +386,7 @@ jobs:
         run: |
             set -euox pipefail
 
-            sudo -E $(command -v just) push-image \
+            $(command -v just) push-image \
               --image "${MATRIX_BASE_NAME}" \
               --tag "${MATRIX_STREAM_NAME}" \
               --flavor "${MATRIX_IMAGE_FLAVOR}" \

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -73,7 +73,6 @@ jobs:
         uses: ublue-os/container-storage-action@25e05be4948f77746938687877829d15c5038036
         continue-on-error: true
         with:
-          target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2
           loopback-free: '1'
 

--- a/Justfile
+++ b/Justfile
@@ -840,6 +840,8 @@ disk-image $image="aurora" $tag="latest" $flavor="main" ghcr="false" $backend="o
       BOOTC_INSTALL_ARGS+=("--bootloader systemd" "--composefs-backend")
     fi
 
+    {{ just }} load-rootful --image "${image}" --tag "${tag}" --flavor "${flavor}"
+
     {{ just }} bootc "${image}" "${tag}" "${flavor}" install to-disk "${BOOTC_INSTALL_ARGS[@]}"
 
 # FIXME: Please consider using podman push in the future for signing as well instead of temporary tag + cosign


### PR DESCRIPTION
26.04 runners use sudo-rs, which does not support this flag. It doesn't
seem to have broken too much, Only thing I could see is the github token
not being passed to the build.

```
sudo: preserving the entire environment is not supported, '-E' is ignored
```

So this is a good time to move over to a rootless CI I guess.