### PR TITLE
fix: relink rpm-ostree-base-db to system rpmdb

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -13,6 +13,19 @@ systemctl disable flatpak-add-fedora-repos.service
 systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 
+# Relink rpm-ostree-base-db to rpmdb to ensure it correctly reflects the system
+# image's rpmdb and doesn't carry over package info from the base image.
+# See: https://github.com/coreos/rpm-ostree/issues/4554
+# https://forge.fedoraproject.org/atomic/tracker/issues/82
+for file in rpmdb.sqlite rpmdb.sqlite-shm rpmdb.sqlite-wal; do
+    target="/usr/share/rpm/${file}"
+    link_path="/usr/lib/sysimage/rpm-ostree-base-db/${file}"
+    if [[ -f "${target}" && -f "${link_path}" ]]; then
+        # Note, this needs to be a hardlink, not a symbolic link.
+        ln -f "${target}" "${link_path}"
+    fi
+done
+
 rm -rf /.gitkeep
 
 find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;


### PR DESCRIPTION
taken from blue-build[1], this also happens to make updates smaller by
100MB. Might fix the following issues like [2] and [3]. I could not
reproduce these issues myself and just using chunkah made it possible
for me to overlay firefox with rpm-ostree (without changes this PR makes)

[1]: https://github.com/blue-build/cli/commit/b6f36bd9a2efff30adb06cf9dba43a24d6f47891
[2]: https://github.com/ublue-os/aurora/issues/2209
[3]: https://github.com/ublue-os/aurora/issues/2492