### PR TITLE
fix(ci): fix the backport action to use the base ref

### DIFF
--- a/.github/workflows/cherry-pick-to-stable.yml
+++ b/.github/workflows/cherry-pick-to-stable.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           # Use the dynamically generated GitHub App token
           token: ${{ steps.generate-token.outputs.token }}
+          # Explicitly check out the base branch (the PR is already merged into it).
+          # Avoids the default `refs/pull/<PR>/merge` ref, which actions/checkout
+          # refuses to check out for fork PRs on pull_request_target events.
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
 
       - name: Configure Git Author


### PR DESCRIPTION
Looks like by default the backport action tries to checkout the fork PR that was merged and that triggers the checkout actions security protections. Not sure why are we seeing this just only now.

This should make it use the base branch explicitly (main) to checkout as the PR is already merged into it.
