### PR TITLE
chore(ci): do not persist credentials in git checkout

### DIFF
--- a/.github/workflows/cherry-pick-to-stable.yml
+++ b/.github/workflows/cherry-pick-to-stable.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          persist-credentials: false
           # Use the dynamically generated GitHub App token
           token: ${{ steps.generate-token.outputs.token }}
           # Explicitly check out the base branch (the PR is already merged into it).

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Checkout last 500 commits (for <commits> to work)
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          persist-credentials: false
           fetch-depth: 500
           ref: stable-f44
 

--- a/.github/workflows/moderator.yml
+++ b/.github/workflows/moderator.yml
@@ -19,6 +19,9 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
       - uses: github/ai-moderator@81159c370785e295c97461ade67d7c33576e9319 # v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -62,6 +62,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       # FIXME: We need both actions as we run out of space on /var/tmp, however this
       # will still fail sometimes as even the smallest 72G runners have a

--- a/.github/workflows/trigger-schedule-stable-image.yml
+++ b/.github/workflows/trigger-schedule-stable-image.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Trigger Stable Image Build
         env:

--- a/.github/workflows/validate-just.yml
+++ b/.github/workflows/validate-just.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Install Just
         run: |

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
We don't need any credentials after the initial clone.

xref: https://github.com/ublue-os/aurora/issues/2528

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
