### PR TITLE
chore(ci): use built-in release function of gh

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -59,11 +59,14 @@ jobs:
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         if: contains(fromJson('["stable"]'), matrix.version) && (github.event.schedule == '0 1 * * TUE' || contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name))
-        with:
-          name: ${{ steps.generate-release-text.outputs.title }}
-          tag_name: ${{ steps.generate-release-text.outputs.tag }}
-          body_path: ./changelog.md
-          make_latest: ${{ matrix.version == 'stable' }}
-          prerelease: false
+        env:
+          TITLE: ${{ steps.generate-release-text.outputs.title }}
+          TAG: ${{ steps.generate-release-text.outputs.tag }}
+          BODY_PATH: ./changelog.md
+        run: |
+          gh release create \
+          "${TAG}" \
+          --title "${TITLE}" \
+          -F "${BODY_PATH}" \
+          --latest


### PR DESCRIPTION
We should not rely on external actions if this functionality exists in official tools.

We are only running this step when it's a stable image build so ommiting the make_latest thing is fine to my understanding.

xref: https://github.com/ublue-os/aurora/issues/2528

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
