### PR TITLE
feat(chunkah): use oci-dir instead of tar-roundtrip

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -329,23 +329,29 @@ build-rechunk $image="aurora" $tag="latest" $flavor="main" $kernel_pin="" $retry
 [group('Image')]
 rechunk $image="aurora" $tag="latest" $flavor="main":
     #!/usr/bin/env bash
+    set -eoux pipefail
 
     {{ just }} validate --image "${image}" --tag "${tag}" --flavor "${flavor}"
     image_name=$({{ just }} image_name --image "${image}" --tag "${tag}" --flavor "${flavor}")
-
-    export CHUNKAH_CONFIG_STR=$(${PODMAN} inspect "${image_name}:${tag}")
-
-    set -eoux pipefail
+    CHUNKAH_OUTPUT_DIR="$(mktemp -d)"
+    CHUNKAH_CONFIG_FILE="$(mktemp)"
+    ${PODMAN} inspect "${image_name}:${tag}" > "${CHUNKAH_CONFIG_FILE}"
 
     ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \
-    -e CHUNKAH_CONFIG_STR "{{ chunkah }}" \
+    -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
+    -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+    "{{ chunkah }}" \
     build \
     --verbose \
     --compressed \
     --max-layers 128 \
     --prune /sysroot/ \
     --label ostree.commit- --label ostree.final-diffid- \
-    --tag "${image_name}:${tag}" | ${PODMAN} load
+    --config /chunkah-config.json \
+    --output oci:/run/out/chunked
+
+    CHUNKED_IMAGE="$(podman pull "oci:${CHUNKAH_OUTPUT_DIR}/chunked")"
+    podman tag "${CHUNKED_IMAGE}" "${image_name}:${tag}"
 
 # build-chunked-oci
 [arg("flavor", long="flavor", short="f")]

--- a/Justfile
+++ b/Justfile
@@ -335,6 +335,8 @@ rechunk $image="aurora" $tag="latest" $flavor="main":
     image_name=$({{ just }} image_name --image "${image}" --tag "${tag}" --flavor "${flavor}")
     CHUNKAH_OUTPUT_DIR="$(mktemp -d)"
     CHUNKAH_CONFIG_FILE="$(mktemp)"
+
+    trap 'rm -f "${CHUNKAH_CONFIG_FILE}"; rm -rf "${CHUNKAH_OUTPUT_DIR}"' EXIT
     ${PODMAN} inspect "${image_name}:${tag}" > "${CHUNKAH_CONFIG_FILE}"
 
     ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \


### PR DESCRIPTION
/tmp is a tmpfs backed by RAM (8G) on github so this will also be faster than the current implementation because of that.

See: https://github.com/coreos/chunkah#output-options

xref: https://github.com/ublue-os/aurora/issues/2350

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
