### PR TITLE
feat(ci): setup runner with containers policy

### DIFF
--- a/.github/setup-runner-keys.sh
+++ b/.github/setup-runner-keys.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Setup Public Keys for containers that are pulled during the build
+
+set -eoux pipefail
+
+PKI_DIR="/etc/pki/containers"
+REGISTRIES="/etc/containers/registries.d"
+
+mkdir -p "${PKI_DIR}" "${REGISTRIES}"
+cp cosign.pub "${PKI_DIR}/ghcr.io-ublue-os.pub"
+cp quay.io-fedora-ostree-desktops.pub "${PKI_DIR}"
+
+yq -n '.docker."ghcr.io/ublue-os".use-sigstore-attachments = true' | tee "${REGISTRIES}"/ublue-os.yaml
+yq -n '.docker."quay.io/fedora-ostree-desktops".use-sigstore-attachments = true' | tee "${REGISTRIES}"/fedora-ostree-desktops.yaml
+
+jq '.transports.docker["ghcr.io/ublue-os"] = [
+  {
+    "type": "sigstoreSigned",
+    "keyPath": "/etc/pki/containers/ghcr.io-ublue-os.pub",
+    "signedIdentity": {
+      "type": "matchRepository"
+    }
+  }
+] |
+.transports.docker["quay.io/fedora-ostree-desktops"] = [
+  {
+    "type": "sigstoreSigned",
+    "keyPath": "/etc/pki/containers/quay.io-fedora-ostree-desktops.pub",
+    "signedIdentity": {
+      "type": "matchRepository"
+    }
+  }
+]' /etc/containers/policy.json | tee /etc/containers/policy.json.tmp > /dev/null && mv /etc/containers/policy.json.tmp /etc/containers/policy.json

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -97,7 +97,6 @@ jobs:
       # FIXME: Implement retries for stuff like this
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        if: inputs.publish
 
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -85,6 +85,10 @@ jobs:
         id: remove-unwanted-software
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
 
+      - name: Configure containers policy for build
+        run: |
+          sudo ./.github/setup-runner-keys.sh
+
       - name: Install Just
         run: |
           /home/linuxbrew/.linuxbrew/bin/brew install just

--- a/Justfile
+++ b/Justfile
@@ -144,7 +144,6 @@ build $image="aurora" $tag="latest" $flavor="main" $rechunk="false" $ghcr="false
 
     BASE_IMAGE_REF="${base_image_org}/${base_image_name}:${fedora_version}"
     ALL_IMAGES=()
-    {{ just }} verify-container quay.io-fedora-ostree-desktops.pub "${BASE_IMAGE_REF}"
     ALL_IMAGES+=("${BASE_IMAGE_REF}")
 
     # Here we pin our kernels to workaround regressions!
@@ -187,18 +186,15 @@ build $image="aurora" $tag="latest" $flavor="main" $rechunk="false" $ghcr="false
     BASENAME_AKMODS="ghcr.io/ublue-os/akmods"
 
     AKMODS="${BASENAME_AKMODS}:${akmods_flavor}-${fedora_version}-${kernel_release}"
-    {{ just }} verify-container cosign.pub "${AKMODS}"
     ALL_IMAGES+=("${AKMODS}")
 
     if [[ "${akmods_flavor}" =~ coreos ]]; then
         AKMODS_ZFS="${BASENAME_AKMODS}-zfs:${akmods_flavor}-${fedora_version}-${kernel_release}"
-        {{ just }} verify-container cosign.pub "${AKMODS_ZFS}"
         ALL_IMAGES+=("${AKMODS_ZFS}")
     fi
 
     if [[ "${flavor}" =~ nvidia-open ]]; then
         AKMODS_NVIDIA_OPEN="${BASENAME_AKMODS}-nvidia-open:${akmods_flavor}-${fedora_version}-${kernel_release}"
-        {{ just }} verify-container cosign.pub "${AKMODS_NVIDIA_OPEN}"
         ALL_IMAGES+=("${AKMODS_NVIDIA_OPEN}")
     fi
 
@@ -216,7 +212,6 @@ build $image="aurora" $tag="latest" $flavor="main" $rechunk="false" $ghcr="false
 
     ALL_IMAGES+=("{{ chunkah }}")
 
-    {{ just }} verify-container cosign.pub "{{ brew }}"
     ALL_IMAGES+=("{{ brew }}")
 
     {{ retry_function }}
@@ -481,33 +476,6 @@ changelogs branch="stable" handwritten="":
     #!/usr/bin/env bash
     set -eou pipefail
     python3 ./.github/changelogs.py "{{ branch }}" ./output.env ./changelog.md --workdir . --handwritten "{{ handwritten }}"
-
-# Verify Container with Cosign
-[group('Utility')]
-verify-container key="" container="":
-    #!/usr/bin/env bash
-    set -eou pipefail
-
-    # Get Cosign if Needed
-    if [[ ! $(command -v cosign) ]]; then
-        COSIGN_CONTAINER_ID=$(${SUDOIF} ${PODMAN} create cgr.dev/chainguard/cosign:latest bash)
-        ${SUDOIF} ${PODMAN} cp "${COSIGN_CONTAINER_ID}":/usr/bin/cosign /usr/local/bin/cosign
-        ${SUDOIF} ${PODMAN} rm -f "${COSIGN_CONTAINER_ID}"
-    fi
-
-    # Verify Cosign Image Signatures if needed
-    if [[ -n "${COSIGN_CONTAINER_ID:-}" ]]; then
-        if ! cosign verify --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main cgr.dev/chainguard/cosign >/dev/null; then
-            echo "NOTICE: Failed to verify cosign image signatures."
-            exit 1
-        fi
-    fi
-
-    # Verify Container using cosign public key
-    if ! cosign verify --key "{{ key }}" "{{ container }}" >/dev/null; then
-        echo "NOTICE: Verification failed. Please ensure your public key is correct."
-        exit 1
-    fi
 
 # Secureboot Check
 [arg("flavor", long="flavor", short="f")]


### PR DESCRIPTION
Currently for ublue-os/akmods and kinoite (not pinned by digest), we
verify them and pull them right after. We can't trust the authenticity
of those images, as the tag in the meantime could point to a different,
potentially compromised digest.

To avoid this, we set up our runner so that it will refuse to pull
anything from Universal Blue or quay.io/fedora-ostree-desktops without
first getting verified with the corresponding public key in our repo.

With this, we can completely get rid of our verify-container recipe and
benefit from the retry logic that is implemented in the podman pulls we
already do beforehand.

This would mean that local builds would no longer verify the pulled
images, as the policy is very likely not configured, but I don't think
that is super important.

xref: https://github.com/ublue-os/aurora/issues/2337