### PR TITLE
feat(ci): do not compress chunkah output

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -328,7 +328,7 @@ rechunk $image="aurora" $tag="latest" $flavor="main":
 
     {{ just }} validate --image "${image}" --tag "${tag}" --flavor "${flavor}"
     image_name=$({{ just }} image_name --image "${image}" --tag "${tag}" --flavor "${flavor}")
-    CHUNKAH_OUTPUT_DIR="$(mktemp -d)"
+    CHUNKAH_OUTPUT_DIR="$(mktemp -d --tmpdir="${PWD}")"
     CHUNKAH_CONFIG_FILE="$(mktemp)"
 
     trap 'rm -f "${CHUNKAH_CONFIG_FILE}"; rm -rf "${CHUNKAH_OUTPUT_DIR}"' EXIT
@@ -340,7 +340,6 @@ rechunk $image="aurora" $tag="latest" $flavor="main":
     "{{ chunkah }}" \
     build \
     --verbose \
-    --compressed \
     --max-layers 128 \
     --prune /sysroot/ \
     --label ostree.commit- --label ostree.final-diffid- \


### PR DESCRIPTION
So we have 2 optimal choices with chunkah, this assumes the --output oci
option, which was only recently introduced which is so much faster
faster than piping into podman load. Which we have used until
ca6ff846ec.

Choice 1, we compress the output and put it in /tmp, we only have 8GB
there. The compressed images range from 3.3GB to 5GB. This means we are
sacrifing speed for disk usage. This is the approach we are currently
using.

Choice 2, we don't compress the output, which makes the podman pull
faster. Our smallest uncompressed image is over 8GB so we can't use /tmp
there. This means we are sacrifing more disk space for speed.

Comparison only for the rechunking step, this includes the import with
podman pull into the containers-storage.

Choice 1:
aurora: 3m 35s
aurora-dx: 4m 45s

Choice 2:
aurora: 2m 16s
aurora-dx: 7m 7s

xref: https://github.com/ublue-os/aurora/issues/2350