### PR TITLE
chore: remove duplicate options from dracut

### DIFF
--- a/build_files/base/19-initramfs.sh
+++ b/build_files/base/19-initramfs.sh
@@ -7,7 +7,7 @@ set -ouex pipefail
 KERNEL_VERSION=$(rpm -q --queryformat="%{evr}.%{arch}" kernel-core)
 
 export DRACUT_NO_XATTR=1
-/usr/bin/dracut --no-hostonly --kver "${KERNEL_VERSION}" --reproducible -v -f "/usr/lib/modules/${KERNEL_VERSION}/initramfs.img"
+/usr/bin/dracut --kver "${KERNEL_VERSION}" --reproducible -v -f "/usr/lib/modules/${KERNEL_VERSION}/initramfs.img"
 chmod 0600 "/usr/lib/modules/${KERNEL_VERSION}/initramfs.img"
 
 echo "::endgroup::"

--- a/system_files/shared/usr/lib/dracut/dracut.conf.d/90-ublue-luks.conf
+++ b/system_files/shared/usr/lib/dracut/dracut.conf.d/90-ublue-luks.conf
@@ -1,1 +1,1 @@
-add_dracutmodules+=" fido2 tpm2-tss pkcs11 pcsc "
+add_dracutmodules+=" fido2 pkcs11 pcsc "


### PR DESCRIPTION
These are already included in our base image as configuration files, there is no need to specify them on the cli again.

See: https://gitlab.com/fedora/ostree/ci-test/-/blob/5f1f192f007b2a7049d027b967b4ed58a0454143/initramfs.yaml

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
