### PR TITLE
feat: add google-noto-sans-cham-fonts

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -64,6 +64,7 @@ FEDORA_PACKAGES=(
     git-credential-libsecret
     glow
     google-noto-sans-balinese-fonts
+    google-noto-sans-cham-fonts
     google-noto-sans-cjk-fonts
     google-noto-sans-javanese-fonts
     google-noto-sans-sundanese-fonts


### PR DESCRIPTION
This is needed to display characters like: ꨄ.

284kib big

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
