### PR TITLE
feat: cleanup dnf files generated during the build

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -8,6 +8,9 @@ set -eoux pipefail
 mv /etc/dnf/dnf.conf.bak /etc/dnf/dnf.conf
 dnf versionlock clear
 
+# this invalidates libdnf5 package (chunkah)
+rm -rf /usr/lib/sysimage/libdnf5/*
+
 # This comes last because we can't *ever* afford to ship fedora flatpaks on the image
 systemctl disable flatpak-add-fedora-repos.service
 systemctl mask flatpak-add-fedora-repos.service


### PR DESCRIPTION
The libdnf5 package owns various files under /usr/lib/sysimage/libdnf5 that are getting generated during the build, for instance, the transaction history (dnf history list), which changes with every build due to timestamps and package versions.

This means that every single image build has a unique libdnf5 package, which results in every update unnecessarily downloading it, although nothing that we care about changed.

dnf history is not useful here; you can look in the build logs if you really wanted to see what transactions are being done. On the client side, things like dnf history undo don't work or are largely not the right tool for the job in custom image builds.

xref: https://github.com/ublue-os/aurora/issues/2579

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
