### PR TITLE
chore(ci): add gh token to release generator

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -65,6 +65,7 @@ jobs:
       - name: Create Release
         if: contains(fromJson('["stable"]'), matrix.version) && (github.event.schedule == '0 1 * * TUE' || contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name))
         env:
+          GH_TOKEN: ${{ github.token }}
           TITLE: ${{ steps.generate-release-text.outputs.title }}
           TAG: ${{ steps.generate-release-text.outputs.tag }}
           BODY_PATH: ./changelog.md

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Create Release
         if: contains(fromJson('["stable"]'), matrix.version) && (github.event.schedule == '0 1 * * TUE' || contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name))
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TITLE: ${{ steps.generate-release-text.outputs.title }}
           TAG: ${{ steps.generate-release-text.outputs.tag }}
           BODY_PATH: ./changelog.md


### PR DESCRIPTION
Seems we need to pass the token to gh cli in workflows too

https://github.com/ublue-os/aurora/actions/runs/29793388914/job/88563341082#step:7:13

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
