### PR TITLE
fix(ci): remove aurora-dx-group service

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -128,7 +128,6 @@ if rpm -q docker-ce >/dev/null; then
 fi
 systemctl enable podman.socket
 systemctl enable ublue-os-libvirt-workarounds.service
-systemctl enable aurora-dx-groups.service
 systemctl enable --global aurora-dx-user-vscode.service
 
 # Disable RPM Fusion repos


### PR DESCRIPTION
Removes the aurora-dx-group service enablement from dx builds

Needed for: https://github.com/ublue-os/aurora/pull/2592
