### PR TITLE
fix(ci): pull cache when it's a PR on sundays

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -782,7 +782,8 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $pull="fa
     CURRENT_DAY="$(LC_TIME=C date +%A)"
     BLESSED_DAY="Sunday"
 
-    if [[ "${CURRENT_DAY}" == "${BLESSED_DAY}" && "$POINT" == "1" && "${ghcr}" == "true" ]]; then
+    # Always attempt to pull cache, but don't on the first run that will publish the build on Sundays
+    if [[ "${CURRENT_DAY}" == "${BLESSED_DAY}" && "$POINT" == "1" && "${ghcr}" == "true" && ( "${github_event}" == "workflow_dispatch" || "${github_event}" == "merge_queue" ) ]]; then
       echo "Not pulling build cache. Uploading fresh cache later."
     elif [[ "${pull}" == "true" ]]; then
       # We want to avoid using --allow-path-traversal
@@ -795,7 +796,9 @@ setup-cache $image="aurora" $tag="latest" $flavor="main" $ghcr="false" $pull="fa
        [[ "${pull:-false}" == "false" ]] && \
        [[ "${push}" == "true" ]] && \
        [[ "${ghcr}" == "true" ]] && \
-       [[ "${github_event}" == "workflow_dispatch" || "${CURRENT_DAY}" == "${BLESSED_DAY}" && "${POINT}" == "1" ]]; then
+       [[ "${CURRENT_DAY}" == "${BLESSED_DAY}" ]] && \
+       [[ "${POINT}" == "1" ]] && \
+       [[ ( "${github_event}" == "workflow_dispatch" || "${github_event}" == "merge_queue" ) ]]; then
 
       {{ just }} login-registry oras ghcr.io
       pushd "${BUILDAH_CACHE_DIR}"


### PR DESCRIPTION
When you make a PR to aurora on a Sunday before the daily renovate bump kicked off (POINT=1) (before 4AM UTC) then this run would not have any cache.

PRs always should have cache.

Spotted in https://github.com/ublue-os/aurora/actions/runs/29173483761/job/86598348413

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
