### PR TITLE
chore(ci): stop hardcoding stable-branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
     "config:best-practices"
   ],
 
-  "baseBranchPatterns": ["main", "stable-f44"],
+  "baseBranchPatterns": ["main", "/^stable-f[0-9][0-9]$/"],
 
   // Do not rebase when the default branch is updated
   "rebaseWhen": "never",
@@ -59,7 +59,7 @@
       ],
       // Brew and common are not "security updates", they have to go through :testing/main first
       // to reach a stable release
-      "matchBaseBranches": ["stable-f44"],
+      "matchBaseBranches": ["/^stable-f[0-9][0-9]$/"],
       "enabled": false
     },
     {

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -2,17 +2,17 @@ name: Latest Images
 on:
   push:
     branches:
-      - stable-f44
+      - 'stable-f[0-9][0-9]'
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"
       - ".github/workflows/scorecard.yml"
   merge_group:
     branches:
-      - stable-f44
+      - 'stable-f[0-9][0-9]'
   pull_request:
     branches:
-      - stable-f44
+      - 'stable-f[0-9][0-9]'
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -6,7 +6,7 @@ on:
   # We still want to know if things are broken
   pull_request:
     branches:
-      - stable-f44
+      - 'stable-f[0-9][0-9]'
     paths-ignore:
       - "**.md"
       - ".github/workflows/moderator.yml"

--- a/.github/workflows/cherry-pick-to-stable.yml
+++ b/.github/workflows/cherry-pick-to-stable.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           # Use the dynamically generated GitHub App token here too
           github_token: ${{ steps.generate-token.outputs.token }}
-          target_branches: "stable-f44"
+          target_branches: ${{ vars.STABLE_BRANCH }}
           add_labels: "backported-to-stable"
           pull_title: '${pull_title} [Backport ${target_branch}]'
           pull_description: |

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 500
-          ref: stable-f44
+          ref: ${{ vars.STABLE_BRANCH }}
 
       - name: Install Just
         run: |

--- a/.github/workflows/trigger-schedule-stable-image.yml
+++ b/.github/workflows/trigger-schedule-stable-image.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Trigger Stable Image Build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: stable-f44
+          BRANCH: ${{ vars.STABLE_BRANCH }}
         run: |
           gh workflow run \
             build-image-stable.yml \


### PR DESCRIPTION
Instead we can define an environment variable for github actions.

For things where we can't, globs/regex is probably good enough.

When we branch/stabilize "stable-f45" then we will delete the old one anyway, so we shouldn't be in a situation where we'll get spammed with like 3 PRs.

The only remaining things where it's hardcoded is the pull config and docs.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
