### PR TITLE
feat: add ZFS deprecation notifier

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -43,6 +43,9 @@ systemctl enable uupd.timer
 # Disable the old update timer
 systemctl disable rpm-ostreed-automatic.timer
 
+# TODO: Remove with F45 release
+systemctl enable aurora-zfs-deprecation-notifier.timer
+
 # Hide Desktop Files. Hidden removes mime associations
 for file in htop nvtop; do
     if [[ -f "/usr/share/applications/${file}.desktop" ]]; then

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -44,7 +44,9 @@ systemctl enable uupd.timer
 systemctl disable rpm-ostreed-automatic.timer
 
 # TODO: Remove with F45 release
-systemctl enable aurora-zfs-deprecation-notifier.timer
+if [[ "${AKMODS_FLAVOR}" =~ coreos ]]; then
+  systemctl enable aurora-zfs-deprecation-notifier.timer
+fi
 
 # Hide Desktop Files. Hidden removes mime associations
 for file in htop nvtop; do

--- a/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
+++ b/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NOTIFICATION="/usr/bin/notify-send --app-name=Aurora --icon distributor-logo --urgency critical 'ZFS is getting removed in Fall 2026' 'You are using ZFS so please take a look at https://github.com/ublue-os/aurora/issues/1765 for more infos. There will not be another reminder.'"
+
+USERS="$(loginctl list-users --no-legend | awk '$1 != 0 {print $2}')"
+
+for username in ${USERS}; do
+  machinectl shell "${username}@.host" /usr/bin/bash -c "${NOTIFICATION}"
+done
+
+touch /etc/.aurora-zfs-deprecation-notifer.stamp
+

--- a/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
+++ b/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-NOTIFICATION="/usr/bin/notify-send --app-name=Aurora --icon distributor-logo --urgency critical 'ZFS is getting removed in Fall 2026' 'You are using ZFS so please take a look at https://github.com/ublue-os/aurora/issues/1765 for more infos. There will not be another reminder.'"
+NOTIFICATION="/usr/bin/notify-send --app-name=Aurora --icon distributor-logo --urgency critical 'ZFS support is ending in October 2026' 'An attached drive contains a ZFS pool. Please see https://github.com/ublue-os/aurora/issues/1765 for more info.'"
 
 USERS="$(loginctl list-users --no-legend | awk '$1 != 0 {print $2}')"
 

--- a/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
+++ b/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
@@ -9,6 +9,3 @@ USERS="$(loginctl list-users --no-legend | awk '$1 != 0 {print $2}')"
 for username in ${USERS}; do
   machinectl shell "${username}@.host" /usr/bin/bash -c "${NOTIFICATION}"
 done
-
-touch /etc/.aurora-zfs-deprecation-notifier.stamp
-

--- a/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
+++ b/system_files/shared/usr/bin/aurora-zfs-deprecation-notifier
@@ -10,5 +10,5 @@ for username in ${USERS}; do
   machinectl shell "${username}@.host" /usr/bin/bash -c "${NOTIFICATION}"
 done
 
-touch /etc/.aurora-zfs-deprecation-notifer.stamp
+touch /etc/.aurora-zfs-deprecation-notifier.stamp
 

--- a/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.service
+++ b/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Aurora ZFS Deprecation Notifier
+Documentation=https://github.com/ublue-os/aurora/issues/1765
+After=local-fs.target
+Wants=local-fs.target
+ConditionPathIsReadWrite=/etc
+ConditionPathExists=!/etc/.aurora-zfs-deprecation-notifer.stamp
+ConditionPathExists=/usr/bin/zfs
+
+[Service]
+Type=oneshot
+ExecCondition=/usr/bin/bash -c "/usr/bin/lsblk -o FSTYPE | /usr/bin/grep -q ^zfs"
+ExecStart=/usr/bin/aurora-zfs-deprecation-notifier
+
+[Install]
+WantedBy=graphical.target

--- a/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.service
+++ b/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.service
@@ -4,7 +4,7 @@ Documentation=https://github.com/ublue-os/aurora/issues/1765
 After=local-fs.target
 Wants=local-fs.target
 ConditionPathIsReadWrite=/etc
-ConditionPathExists=!/etc/.aurora-zfs-deprecation-notifer.stamp
+ConditionPathExists=!/etc/.aurora-zfs-deprecation-notifier.stamp
 ConditionPathExists=/usr/bin/zfs
 
 [Service]

--- a/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.service
+++ b/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.service
@@ -4,7 +4,6 @@ Documentation=https://github.com/ublue-os/aurora/issues/1765
 After=local-fs.target
 Wants=local-fs.target
 ConditionPathIsReadWrite=/etc
-ConditionPathExists=!/etc/.aurora-zfs-deprecation-notifier.stamp
 ConditionPathExists=/usr/bin/zfs
 
 [Service]

--- a/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.timer
+++ b/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Run aurora-zfs-deprecation-notifier 20 mins after boot
+
+[Timer]
+OnBootSec=20min
+Unit=aurora-zfs-deprecation-notifier.service
+
+[Install]
+WantedBy=timers.target

--- a/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.timer
+++ b/system_files/shared/usr/lib/systemd/system/aurora-zfs-deprecation-notifier.timer
@@ -4,6 +4,8 @@ Description=Run aurora-zfs-deprecation-notifier 20 mins after boot
 [Timer]
 OnBootSec=20min
 Unit=aurora-zfs-deprecation-notifier.service
+OnUnitActiveSec=1w
+Persistent=true
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
This will spawn a notification every week that has to be dismissed by the user if ZFS is being used.

This can be permanently disabled with:

```
sudo systemctl disable aurora-zfs-deprecation-notifier.timer
```

xref: https://github.com/ublue-os/aurora/issues/1765
resolves: https://github.com/ublue-os/aurora/issues/2210

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
