### PR TITLE
chore: pin kernel to 7.0.12-201 because of ZFS

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -158,8 +158,8 @@ build $image=default_image $tag=default_tag $flavor=default_flavor $rechunk="fal
       case "${tag}" in
               stable)
                   if [[ "${ARCH}" == "x86_64" ]]; then
-                      # <Here is a link why we have it pinned>
-                      kernel_pin=""
+                      # https://github.com/openzfs/zfs/issues/18760
+                      kernel_pin="7.0.12-201.fc44.x86_64"
                   elif [[ "${ARCH}" == "aarch64" ]]; then
                       kernel_pin=""
                   fi


### PR DESCRIPTION
Stable builds are currently failing because of this

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
