### PR TITLE
chore: update renovate for github-action to weekly

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -63,10 +63,12 @@
       "enabled": false
     },
     {
+      "matchManagers": ["github-actions"],
       "matchDepNames": [
-        "github/codeql-action/upload-sarif"
+        "!oras-project/setup-oras",
+        "!sigstore/cosign-installer"
       ],
-      "extends": ["schedule:weekly"]
+      "schedule": ["on sunday"]
     }
   ]
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -66,7 +66,8 @@
       "matchManagers": ["github-actions"],
       "matchDepNames": [
         "!oras-project/setup-oras",
-        "!sigstore/cosign-installer"
+        "!sigstore/cosign-installer",
+        "!anchore/sbom-action"
       ],
       "schedule": ["on sunday"]
     }


### PR DESCRIPTION
This should put update our github-actions only on sundays once a week and not bombard us constantly.

 cosign-installer and oras-setup are exceptions, if there are some others we can add them to the list

https://github.com/ublue-os/aurora/issues/2629
