### PR TITLE
chore(ci): pin cosign

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -97,6 +97,9 @@ jobs:
       # FIXME: Implement retries for stuff like this
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        # be careful when upgrading major versions
+        with:
+          cosign-release: 'v3.1.2'
 
       - name: Install ORAS
         uses: oras-project/setup-oras@1d808f7d7f6995cc68b7bf507bfe5c5446e1dc9d # v2.0.1


### PR DESCRIPTION
This is a ticking time bomb, so we don't accidentally use cosign v4 when it comes out and so on, renovate should pick this up.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
