### PR TITLE
feat: set SOURCE_DATE_EPOCH on chunkah

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -341,6 +341,7 @@ rechunk $image=default_image $tag=default_tag $flavor=default_flavor:
     ${PODMAN} run --rm --mount=type=image,src="${image_name}:${tag}",target=/chunkah \
     -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
     -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+    -e SOURCE_DATE_EPOCH=0 \
     "{{ chunkah }}" \
     build \
     --verbose \


### PR DESCRIPTION
Should help with reproducibility and might make updates smaller for unpackaged contents like wallpapers, homebrew.

Only downside so far that I see is that `podman images` and the like will show up at the bottom with 56 years ago and so on. Labels like `org.opencontainers.image.created` are of course not affected by this.

xref: https://github.com/ublue-os/aurora/issues/2350 and https://github.com/ublue-os/aurora/issues/2579

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
