### PR TITLE
feat: add google-noto-sans-linear fonts

### DIFF
--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -67,6 +67,8 @@ FEDORA_PACKAGES=(
     google-noto-sans-cham-fonts
     google-noto-sans-cjk-fonts
     google-noto-sans-javanese-fonts
+    google-noto-sans-linear-a-fonts
+    google-noto-sans-linear-b-fonts
     google-noto-sans-sundanese-fonts
     grub2-tools-extra
     gum


### PR DESCRIPTION
Makes characters like 𐀔 and 𐘃 displayable.

fixes: https://github.com/ublue-os/aurora/issues/2682

120 KiB big
