### PR TITLE
fix: preserve shared system files after package removal

### DIFF
--- a/Containerfile.in
+++ b/Containerfile.in
@@ -130,6 +130,7 @@ RUN --mount=type=tmpfs,dst=/boot \
 RUN --network=none \
     --mount=type=tmpfs,dst=/boot \
     --mount=type=bind,from=ctx,source=/,target=/ctx \
+    /ctx/build_files/shared/build-final.sh && \
     /ctx/build_files/base/16-override-install.sh && \
     /ctx/build_files/base/17-cleanup.sh && \
     /ctx/build_files/base/18-image-info.sh && \

--- a/build_files/base/01-packages.sh
+++ b/build_files/base/01-packages.sh
@@ -4,6 +4,8 @@ echo "::group:: ===$(basename "$0")==="
 
 set -ouex pipefail
 
+test -f /etc/dnf/plugins/copr.vendor.conf
+
 # may break when partially upgraded
 dnf versionlock add "qt6-*" "plasma-desktop"
 

--- a/build_files/base/03-fetch.sh
+++ b/build_files/base/03-fetch.sh
@@ -8,6 +8,8 @@ set -eoux pipefail
 curl --retry 3 -Lo /etc/flatpak/remotes.d/flathub.flatpakrepo https://dl.flathub.org/repo/flathub.flatpakrepo
 
 # Offline Aurora documentation
+test -f /usr/share/applications/dev.getaurora.offline-docs.desktop
+test -d /usr/share/ublue-os
 ghcurl "https://github.com/ublue-os/aurora-docs/releases/download/0.1/aurora.pdf" --retry 3 -o /tmp/aurora.pdf
 install -Dm0644 -t /usr/share/doc/aurora/ /tmp/aurora.pdf
 setfattr -n user.component -v "aurora-offline-docs" /usr/share/doc/aurora/aurora.pdf
@@ -42,4 +44,3 @@ chmod +x /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 setfattr -n user.component -v "aurora-config" /usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 
 echo "::endgroup::"
-

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -48,6 +48,10 @@ test -f /etc/flatpak/remotes.d/flathub.flatpakrepo
 # Make sure to not pull in the bazzite one
 rpm -q plasma-setup --qf "%{RELEASE}" | grep -q aurora
 
+# The common overlay restores this customization after plasma-welcome-fedora is removed.
+test -f /usr/share/plasma/plasma-welcome/intro-customization.desktop
+! rpm -q plasma-welcome-fedora
+
 test -f /usr/share/doc/aurora/aurora.pdf
 test -f /usr/share/homebrew.tar.zst
 

--- a/build_files/shared/build-final.sh
+++ b/build_files/shared/build-final.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/bash
+
+set -eoux pipefail
+
+echo "::group:: Copy Final Files"
+
+# Apply the complete overlay after package removals so replacement files remain.
+rsync -rvKl /ctx/system_files/shared/ /
+
+setfattr -n user.component -v "aurora-wallpapers" /usr/share/backgrounds/aurora
+setfattr -n user.update-interval -v "monthly" /usr/share/backgrounds/aurora
+
+setfattr -n user.component -v "aurora-assets" /usr/share/plasma/avatars/{echo,lumina,scope,tina,vincent}.png
+setfattr -n user.component -v "aurora-assets" /etc/bazaar/*.jxl
+setfattr -n user.update-interval -v "quarterly" /etc/bazaar/*.jxl
+
+setfattr -n user.component -v "aurora-plasma-theme" /usr/share/plasma/look-and-feel/dev.getaurora.aurora{,light}.desktop
+setfattr -n user.update-interval -v "quarterly" /usr/share/plasma/look-and-feel/dev.getaurora.aurora{,light}.desktop
+
+setfattr -n user.component -v "aurora-config" /usr/share/ublue-os
+setfattr -n user.component -v "homebrew" /usr/share/homebrew.tar.zst
+
+echo "::endgroup::"

--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -15,21 +15,11 @@ dnf config-manager setopt keepcache=1 timeout=60
 dnf -y swap fedora-logos generic-logos
 rpm --erase --nodeps --nodb generic-logos
 
-# Copy Files to Container
-rsync -rvKl /ctx/system_files/shared/ /
-
-setfattr -n user.component -v "aurora-wallpapers" /usr/share/backgrounds/aurora
-setfattr -n user.update-interval -v "monthly" /usr/share/backgrounds/aurora
-
-setfattr -n user.component -v "aurora-assets" /usr/share/plasma/avatars/{echo,lumina,scope,tina,vincent}.png
-setfattr -n user.component -v "aurora-assets" /etc/bazaar/*.jxl
-setfattr -n user.update-interval -v "quarterly" /etc/bazaar/*.jxl
-
-setfattr -n user.component -v "aurora-plasma-theme" /usr/share/plasma/look-and-feel/dev.getaurora.aurora{,light}.desktop
-setfattr -n user.update-interval -v "quarterly" /usr/share/plasma/look-and-feel/dev.getaurora.aurora{,light}.desktop
-
-setfattr -n user.component -v "aurora-config" /usr/share/ublue-os
-setfattr -n user.component -v "homebrew" /usr/share/homebrew.tar.zst
+# Copy only files needed by package and fetch stages. The full overlay is applied
+# after package removals so replaced RPM-owned files are retained.
+install -Dm0644 /ctx/system_files/shared/etc/dnf/plugins/copr.vendor.conf /etc/dnf/plugins/copr.vendor.conf
+install -Dm0644 /ctx/system_files/shared/usr/share/applications/dev.getaurora.offline-docs.desktop /usr/share/applications/dev.getaurora.offline-docs.desktop
+rsync -rvKl /ctx/system_files/shared/usr/share/ublue-os/ /usr/share/ublue-os/
 
 if [[ "${IMAGE_FLAVOR}" == "dx" ]]; then
   /ctx/build_files/shared/build-dx.sh


### PR DESCRIPTION
## Summary
- split build-critical shared files from the final overlay
- apply the full shared overlay after excluded packages are removed
- add assertions for early dependencies and the Plasma Welcome customization

## Verification
- just check
- Gentle AI review gate: pre-commit

Closes #2687