### PR TITLE
fix: move negativo package in correct array

### DIFF
--- a/build_scripts/base/01-packages.sh
+++ b/build_scripts/base/01-packages.sh
@@ -85,10 +85,8 @@ FEDORA_PACKAGES=(
     krb5-workstation
     ksshaskpass
     ksystemlog
-    libavcodec
     libcamera-gstreamer
     libcamera-tools
-    libfdk-aac
     libimobiledevice-utils
     libratbag-ratbagd
     libxcrypt-compat
@@ -126,6 +124,7 @@ FEDORA_PACKAGES_AMD64=(
 
 NEGATIVO_PACKAGES=(
     ffmpeg{,-libs}
+    libavcodec
     libfdk-aac
     libva-utils
     pipewire-libs-extra


### PR DESCRIPTION
We get libavcodec from negativo, it doesn't belong in the group where only fedora packages should be listed.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
