### PR TITLE
chore(ci): remove aurora brand name

### DIFF
--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -34,13 +34,8 @@ jobs:
       artifact-metadata: write
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-    strategy:
-      fail-fast: false
-      matrix:
-        brand_name: ["aurora"]
     with:
       image_flavors: '["main", "nvidia-open"]'
-      brand_name: ${{ matrix.brand_name }}
       stream_name: latest
       # FIXME: MAIN has no arm builds in ublue-os/akmods yet
       # https://github.com/ublue-os/akmods/pull/440

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -28,12 +28,7 @@ jobs:
       artifact-metadata: write
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-    strategy:
-      fail-fast: false
-      matrix:
-        brand_name: ["aurora"]
     with:
-      brand_name: ${{ matrix.brand_name }}
       stream_name: stable
       # Enable ARM when it makes sense
       # architecture: '["aarch64","x86_64"]'

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -25,13 +25,8 @@ jobs:
       artifact-metadata: write
     secrets:
       SIGNING_SECRET: ${{ secrets.SIGNING_SECRET }}
-    strategy:
-      fail-fast: false
-      matrix:
-        brand_name: ["aurora"]
     with:
       image_flavors: '["main", "nvidia-open"]'
-      brand_name: ${{ matrix.brand_name }}
       stream_name: testing
       # FIXME: MAIN has no arm builds in ublue-os/akmods yet
       # https://github.com/ublue-os/akmods/pull/440

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -8,7 +8,7 @@ on:
         type: string
       brand_name:
         description: "The Brand Name: aurora"
-        required: true
+        required: false
         default: aurora
         type: string
       stream_name:


### PR DESCRIPTION
This probably used to be needed when aurora was built in
ublue-os/bluefin but never cleaned up.
