### PR TITLE
fix: install patched ostree to fix flatpak delta updates (#2738)

### DIFF
--- a/build_scripts/base/01-packages.sh
+++ b/build_scripts/base/01-packages.sh
@@ -211,6 +211,10 @@ dnf -y copr disable ublue-os/staging
 dnf -y swap --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
   plasma-setup plasma-setup-"${PLASMA_VERS}"-*.aurora
 
+# https://github.com/ostreedev/ostree/issues/3635
+dnf -y swap --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+  ostree ostree
+
 dnf versionlock add plasma-setup
 
 # Install DX specific packages


### PR DESCRIPTION
This version from our copr has the fix for this issue applied.

https://github.com/ostreedev/ostree/issues/3635
(cherry picked from commit f1a1190c69d39f5686bc4513d80ce45d797e7c1a)

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
