### PR TITLE
feat: add plasma-union

### DIFF
--- a/build_scripts/base/01-packages.sh
+++ b/build_scripts/base/01-packages.sh
@@ -100,6 +100,7 @@ FEDORA_PACKAGES=(
     pamu2fcfg
     plasma-wallpapers-dynamic
     plasma-firewall-"${PLASMA_VERS}"
+    plasma-union-"${PLASMA_VERS}"
     powertop
     rclone
     restic


### PR DESCRIPTION
Union is still in development but I think we should preinstall it so people can try it if they want to. This will be pre-installed in Fedora at some point and be made an upstream default anyway.

I actually wanted to preinstall this when 6.7 initially came out but I forgot add this.

More info here https://kde.org/announcements/plasma/6/6.6.91/

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
