### PR TITLE
fix: remove stale mariadb SELinux module from local policy store

### DIFF
--- a/build_scripts/base/17-cleanup.sh
+++ b/build_scripts/base/17-cleanup.sh
@@ -25,6 +25,10 @@ systemctl enable flatpak-nuke-fedora.service
 # DO NOT REMOVE THIS
 systemctl enable rechunker-group-fix.service
 
+# Remove stale mariadb SELinux module from the local policy store
+# https://github.com/ublue-os/aurora/issues/2767
+systemctl enable aurora-selinux-cleanup.service
+
 # run flatpak preinstall once at startup
 systemctl enable flatpak-preinstall.service
 

--- a/system_files/shared/usr/bin/aurora-selinux-cleanup
+++ b/system_files/shared/usr/bin/aurora-selinux-cleanup
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Remove the mariadb-plugin-cracklib-password-check module from the local SELinux
+# policy store. The module gets installed into /etc/selinux by the
+# mariadb-cracklib-password-check package, and since /etc persists between
+# updates its remnants break `ostree-finalize-staged` (`semodule --refresh`)
+# when switching to images without the package:
+# https://github.com/ublue-os/aurora/issues/2767
+
+MODULE="mariadb-plugin-cracklib-password-check"
+STORE="/etc/selinux/targeted"
+
+# Nothing to do without a policy store
+if [[ ! -d "${STORE}" ]]; then
+  exit 0
+fi
+
+# Collect any leftover module files, both installed modules and stale
+# policy store transactions
+shopt -s nullglob
+leftovers=(
+  "${STORE}"/active/modules/*/"${MODULE}"
+  "${STORE}"/tmp/modules/*/"${MODULE}"
+)
+shopt -u nullglob
+
+# Nothing to do without any trace of the module
+if [[ ${#leftovers[@]} -eq 0 ]] &&
+  ! semodule -l 2>/dev/null | grep -qw "${MODULE}"; then
+  exit 0
+fi
+
+echo "Removing stale '${MODULE}' SELinux module"
+if ! semodule -X 200 -r "${MODULE}"; then
+  # The policy store may be inconsistent, removing the files directly
+  # lets the next policy rebuild succeed.
+  echo "'semodule' failed, removing leftover module files directly" >&2
+fi
+
+if [[ ${#leftovers[@]} -gt 0 ]]; then
+  rm -rf "${leftovers[@]}"
+fi

--- a/system_files/shared/usr/lib/systemd/system/aurora-selinux-cleanup.service
+++ b/system_files/shared/usr/lib/systemd/system/aurora-selinux-cleanup.service
@@ -1,0 +1,20 @@
+# The mariadb-cracklib-password-check package ships a SELinux policy module that
+# is installed into the persistent /etc/selinux policy store. Remnants of it
+# break `ostree-finalize-staged` when upgrading to or rebasing onto images that
+# do not ship the package, leaving systems unable to complete updates.
+# This unit removes the module from the local policy store before that can
+# happen. Nothing in the image loads this MariaDB plugin.
+# https://github.com/ublue-os/aurora/issues/2767
+[Unit]
+Description=Remove stale mariadb SELinux policy module
+Documentation=https://github.com/ublue-os/aurora/issues/2767
+Wants=local-fs.target
+After=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/aurora-selinux-cleanup
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Fixes [issue 2767](https://github.com/ublue-os/aurora/issues/2767)

The mariadb-cracklib-password-check package (pulled in by the kinoite base via akonadi-server-mysql) installs the
mariadb-plugin-cracklib-password-check SELinux module into the persistent /etc/selinux policy store. Remnants of it break ostree-finalize-staged during upgrades or rebases onto images that do not ship the package, leaving systems unable to complete updates.

Add a oneshot systemd unit which removes the module from the local policy store at boot, including stale transaction leftovers, so that switching between images with and without the package finalizes cleanly.