### PR TITLE
feat: set Meta+Enter to open konsole

### DIFF
--- a/build_scripts/base/16-override-install.sh
+++ b/build_scripts/base/16-override-install.sh
@@ -41,4 +41,7 @@ sed -i '/^\[homes\]/,/^\[/{/^\[homes\]/d;/^\[/!d}' /etc/samba/smb.conf
 # So we can bind offline docs to a shortcut
 cp /usr/share/applications/dev.getaurora.offline-docs.desktop /usr/share/kglobalaccel/
 
+# Meta+Enter rules
+desktop-file-edit --set-key=X-KDE-Shortcuts --set-value='Ctrl+Alt+T,Meta+Return' /usr/share/applications/org.kde.konsole.desktop
+
 echo "::endgroup::"


### PR DESCRIPTION
This is a very common shortcut and I've been using this for years. To my knowledge we can't make a standalone config for this so this will sadly have to be done this way.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
