### PR TITLE
chore: symlink instead of copy for docs desktop

### DIFF
--- a/build_scripts/base/16-override-install.sh
+++ b/build_scripts/base/16-override-install.sh
@@ -39,6 +39,6 @@ setsebool -P samba_export_all_rw=1
 sed -i '/^\[homes\]/,/^\[/{/^\[homes\]/d;/^\[/!d}' /etc/samba/smb.conf
 
 # So we can bind offline docs to a shortcut
-cp /usr/share/applications/dev.getaurora.offline-docs.desktop /usr/share/kglobalaccel/
+ln -s /usr/share/applications/dev.getaurora.offline-docs.desktop /usr/share/kglobalaccel/
 
 echo "::endgroup::"


### PR DESCRIPTION
This is enough, these symlinks are also used on spectacle and dolphin.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
