### PR TITLE
fix: introduce yet another hack for plasma-welcome

### DIFF
--- a/build_scripts/base/16-override-install.sh
+++ b/build_scripts/base/16-override-install.sh
@@ -44,4 +44,7 @@ ln -s /usr/share/applications/dev.getaurora.offline-docs.desktop /usr/share/kglo
 # Meta+Enter rules
 desktop-file-edit --set-key=X-KDE-Shortcuts --set-value='Ctrl+Alt+T,Meta+Return' /usr/share/applications/org.kde.konsole.desktop
 
+# HACK for https://github.com/ublue-os/aurora/issues/2624 https://bugs.kde.org/show_bug.cgi?id=523540
+desktop-file-edit --set-key=Exec --set-value=plasma-welcome-hack /usr/share/applications/org.kde.plasma-welcome.desktop
+
 echo "::endgroup::"

--- a/system_files/shared/usr/bin/plasma-welcome-hack
+++ b/system_files/shared/usr/bin/plasma-welcome-hack
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# https://github.com/ublue-os/aurora/issues/2624
+# https://bugs.kde.org/show_bug.cgi?id=523540
+# real nasty, this is the same ordering as without --pages
+exec /usr/bin/plasma-welcome --pages Welcome,SimpleByDefault,PowerfulWhenNeeded,Feedback,Enjoy "$@"


### PR DESCRIPTION
Seems like [1] doesn't succesfully avoid the crash [2] anymore.
[1] https://github.com/get-aurora-dev/common/commit/28529d0da015bc80e8920a2e3604b4d413f24362
[2] https://github.com/ublue-os/aurora/issues/2624

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
