### PR TITLE
feat: switch to cardwire for managing multi-GPU systems

### DIFF
--- a/build_scripts/base/01-packages.sh
+++ b/build_scripts/base/01-packages.sh
@@ -13,6 +13,12 @@ PLASMA_VERS=$(rpm -q --qf "%{VERSION}" plasma-desktop)
 dnf config-manager addrepo --from-repofile="https://negativo17.org/repos/fedora-multimedia.repo"
 dnf config-manager setopt fedora-multimedia.priority=90
 
+# shellcheck disable=SC2016
+dnf -y install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terra$releasever' terra-release
+
+# Disable Terra Mirrors because they are very flakey
+sed -i -e "s/^#baseurl/baseurl/" -e "s/^metalink/#metalink/" /etc/yum.repos.d/terra.repo
+
 OVERRIDES=(
     "intel-gmmlib"
     "intel-mediasdk"
@@ -142,6 +148,16 @@ if [[ $(arch) == x86_64 ]]; then
 fi
 
 dnf -y install "${PACKAGES[@]}"
+
+TERRA_PACKAGES=(
+    cardwire-gui
+  )
+
+# shellcheck disable=SC1010
+dnf do -y \
+  --action install "${TERRA_PACKAGES[@]}" \
+  --action remove switcheroo-control \
+  --action install cardwire
 
 # Fedora Tailscale is usually behind
 dnf config-manager addrepo --from-repofile=https://pkgs.tailscale.com/stable/fedora/tailscale.repo

--- a/build_scripts/base/17-cleanup.sh
+++ b/build_scripts/base/17-cleanup.sh
@@ -14,6 +14,7 @@ systemctl enable ublue-system-setup.service
 systemctl --global enable ublue-user-setup.service
 systemctl --global enable podman-auto-update.timer
 systemctl enable input-remapper.service
+systemctl enable cardwired.service
 
 # Nuke possible Fedora flatpak repos
 systemctl enable flatpak-nuke-fedora.service
@@ -65,7 +66,7 @@ for repo in fedora-multimedia tailscale fedora-cisco-openh264; do
     fi
 done
 
-# Disable Terra repos (installed on F42 and earlier)
+# Disable Terra repos
 for i in /etc/yum.repos.d/terra*.repo; do
     if [[ -f "$i" ]]; then
         sed -i 's@enabled=1@enabled=0@g' "$i"


### PR DESCRIPTION
I'm not super familiar with these kinds of setups. This definitely needs a couple testers. Supposedly this is better than switcheroo.

Bazzite has a shim [1], I'm not sure how important this is for us as we use Flatpaked Gamerslop.

1: https://github.com/ublue-os/bazzite/blob/61a0554a8c5af47bb206884cdca25b64e51a9a9b/system_files/overrides/usr/bin/switcherooctl

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
