### PR TITLE
chore: remove patched ostree pkg

### DIFF
--- a/build_scripts/base/01-packages.sh
+++ b/build_scripts/base/01-packages.sh
@@ -200,10 +200,6 @@ dnf -y copr disable ublue-os/staging
 dnf -y swap --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
   plasma-setup plasma-setup-"${PLASMA_VERS}"-*.aurora
 
-# https://github.com/ostreedev/ostree/issues/3635
-dnf -y swap --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
-  ostree ostree
-
 dnf versionlock add plasma-setup
 
 # Install DX specific packages


### PR DESCRIPTION
the fixed version is now in fedora repos

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
