### PR TITLE
fix(changelogs): use kernel-core instead of kernel

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -52,7 +52,7 @@ From previous `{target}` version `{prev}` there have been the following changes.
 ### Major packages
 | Name | Version |
 | --- | --- |
-| **Kernel** | {pkgrel:kernel} |
+| **Kernel** | {pkgrel:kernel-core} |
 | **KDE** | {pkgrel:plasma-desktop} |
 | **Mesa** | {pkgrel:mesa-filesystem} |
 | **Nvidia** | {pkgrel:nvidia-driver} |
@@ -93,7 +93,7 @@ HANDWRITTEN_PLACEHOLDER = """\
 This is an automatically generated changelog for release `{curr}`."""
 
 BLACKLIST_VERSIONS = [
-    "kernel",
+    "kernel-core",
     "plasma-desktop",
     "mesa-filesystem",
     "podman",

--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -92,15 +92,20 @@ Be sure to read the [documentation](https://docs.getaurora.dev/) for more inform
 HANDWRITTEN_PLACEHOLDER = """\
 This is an automatically generated changelog for release `{curr}`."""
 
+# this should be synced with the major packages above
 BLACKLIST_VERSIONS = [
     "kernel-core",
     "plasma-desktop",
     "mesa-filesystem",
+    "nvidia-driver",
     "podman",
-    "docker-ce",
+    "bootc",
+    "flatpak",
+    "ostree",
+    "rpm-ostree",
     "incus",
-    "devpod",
-    "nvidia-driver"
+    "docker-ce",
+    "rocm-runtime",
 ]
 
 


### PR DESCRIPTION
This happens to work around the fact that kernel in the SBOM collides with another package. It will now show the correct kernel, however, the underlying issue is not fixed. Besides that bug, we should probably be using this package anyway as kernel is just an empty metapackage with no actual content.

xref: https://github.com/ublue-os/aurora/issues/2817
