### PR TITLE
feat: make compatible with unsealed composefs

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -876,7 +876,7 @@ disk-image $image=default_image $tag=default_tag $flavor=default_flavor $ghcr="f
     if [[ "${backend}" == "ostree" ]]; then
       BOOTC_INSTALL_ARGS+=("--bootloader grub")
     else
-      BOOTC_INSTALL_ARGS+=("--bootloader systemd" "--composefs-backend")
+      BOOTC_INSTALL_ARGS+=("--bootloader grub" "--composefs-backend")
     fi
 
     {{ just }} bootc --image "${image}" --tag "${tag}" --flavor "${flavor}" install to-disk -- "${BOOTC_INSTALL_ARGS[@]}"

--- a/build_scripts/base/16-override-install.sh
+++ b/build_scripts/base/16-override-install.sh
@@ -10,6 +10,9 @@ mv /usr/bin/plasma-welcome /usr/bin/plasma-welcome-original
 # Copy Files to Container
 rsync -rvKl /ctx/system_files/shared/ /
 
+# this adds bootc and ostree to the initramfs
+cp /usr/share/doc/bootc/baseimage/dracut/usr/lib/dracut.conf.d/10-bootc-base.conf /usr/lib/dracut/dracut.conf.d/
+
 # Footgun, See: https://github.com/ublue-os/main/issues/598
 rm -f /usr/bin/chsh /usr/bin/lchsh
 

--- a/system_files/shared/usr/lib/dracut/dracut.conf.d/30-aurora-bootc-ostree-backend.conf
+++ b/system_files/shared/usr/lib/dracut/dracut.conf.d/30-aurora-bootc-ostree-backend.conf
@@ -1,1 +1,0 @@
-add_dracutmodules+=" ostree "


### PR DESCRIPTION
The bootc package ships a dracut configuration that adds the bootc
module (which is needed for the installation of the composefs backend)
to the initramfs which we currently don't have and ostree is also set
there.

I want this because bootc install is significantly faster when used with
the composefs backend, because it does some magic zeor-copy reflink
things. It is wired up with `just disk-image --backend composefs`.

For a long time systemd-boot was the only supported bootloader on
composefs backend, but grub works now. So we don't have to unnecessarily
add systemd-boot to the image.