### PR TITLE
fix(changelogs): don't show kernel in big list

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -95,6 +95,7 @@ This is an automatically generated changelog for release `{curr}`."""
 # this should be synced with the major packages above
 BLACKLIST_VERSIONS = [
     "kernel-core",
+    "kernel",
     "plasma-desktop",
     "mesa-filesystem",
     "nvidia-driver",


### PR DESCRIPTION
We are already showing the kernel in the major packages list. This is a follow-up of 1ddf69d039797762.

Seen in [1].

[1] https://github.com/ublue-os/aurora/releases/tag/stable-20260908.1

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
