### PR TITLE
feat: drop Docker Model Runner in favor of llmman

### DIFF
--- a/build_scripts/dx/00-dx.sh
+++ b/build_scripts/dx/00-dx.sh
@@ -82,8 +82,7 @@ dnf -y install --enablerepo=docker-ce-stable \
     docker-buildx-plugin \
     docker-ce \
     docker-ce-cli \
-    docker-compose-plugin \
-    docker-model-plugin
+    docker-compose-plugin
 
 # VSCode package from Microsoft repo
 echo "Installing VSCode from official repo..."


### PR DESCRIPTION
## What does this change?

Removes `docker-model-plugin` from the DX Docker package set in `build_scripts/dx/00-dx.sh`.

## Why?

[llmman](https://github.com/llmmanorg/llmman) covers the same local model runner use case as Docker Model Runner: it pulls models from Hugging Face or any OCI registry, serves them with upstream `llama.cpp`/`vllm`, and launches coding agents against local or hosted models. It is installed via Homebrew from the shared `ai-tools.Brewfile` (`ujust bbrew` -> `ai`), so the Docker plugin is no longer needed in the image.

Related PRs:
- projectbluefin/common: adds llmman to `ai-tools.Brewfile`
- ublue-os/bluefin, ublue-os/bluefin-lts: same `docker-model-plugin` removal
- ublue-os/aurora-docs: documents llmman