### PR TITLE
feat: add setroubleshoot-plugins

### DIFF
--- a/build_scripts/base/01-packages.sh
+++ b/build_scripts/base/01-packages.sh
@@ -106,6 +106,7 @@ FEDORA_PACKAGES=(
     restic
     samba-winbind{,-clients,-modules}
     setools-console
+    setroubleshoot-plugins
     solaar-udev
     squashfs-tools
     symlinks


### PR DESCRIPTION
This provides utilities to debug SELinux related things like with sealert.

SELinux is already plenty fun on its own, let's make it easier to debug. This has already been included in dx images due to being a dependency of cockpit-selinux.

Seen in https://github.com/ublue-os/main/issues/2845.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
